### PR TITLE
Fix constraint error on playTimerRegulations.bedtimeStartingTime

### DIFF
--- a/pynintendoparental/const.py
+++ b/pynintendoparental/const.py
@@ -5,8 +5,8 @@ import logging
 
 _LOGGER = logging.getLogger(__package__)
 MOBILE_APP_PKG = "com.nintendo.znma"
-MOBILE_APP_VERSION = "1.20.0"
-MOBILE_APP_BUILD = "282"
+MOBILE_APP_VERSION = "1.23.0"
+MOBILE_APP_BUILD = "293"
 OS_NAME = "ANDROID"
 OS_VERSION = "33"
 OS_STR = f"{OS_NAME} {OS_VERSION}"

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -122,7 +122,10 @@ class Device:
                 self.device_id,
                 minutes)
             self.parental_control_settings["playTimerRegulations"]["dailyRegulations"]["timeToPlayInOneDay"]["enabled"] = ttpiod
-            self.parental_control_settings["playTimerRegulations"]["dailyRegulations"]["timeToPlayInOneDay"]["limitTime"] = minutes
+            if "limitTime" in self.parental_control_settings["playTimerRegulations"]["dailyRegulations"]["timeToPlayInOneDay"] and minutes is None:
+                self.parental_control_settings["playTimerRegulations"]["dailyRegulations"]["timeToPlayInOneDay"].pop("limitTime")
+            else:
+                self.parental_control_settings["playTimerRegulations"]["dailyRegulations"]["timeToPlayInOneDay"]["limitTime"] = minutes
             await self._set_parental_control_setting()
         else:
             _LOGGER.debug(
@@ -133,7 +136,10 @@ class Device:
             day_of_week_regs = self.parental_control_settings["playTimerRegulations"]["eachDayOfTheWeekRegulations"]
             current_day = DAYS_OF_WEEK[datetime.now().weekday()]
             day_of_week_regs[current_day]["timeToPlayInOneDay"]["enabled"] = ttpiod
-            day_of_week_regs[current_day]["timeToPlayInOneDay"]["limitTime"] = minutes
+            if "limitTime" in day_of_week_regs[current_day]["timeToPlayInOneDay"] and minutes is None:
+                day_of_week_regs[current_day]["timeToPlayInOneDay"].pop("limitTime")
+            else:
+                day_of_week_regs[current_day]["timeToPlayInOneDay"]["limitTime"] = minutes
             await self._set_parental_control_setting()
 
     def _get_update_parental_control_setting_body(self):
@@ -191,6 +197,10 @@ class Device:
             DEVICE_ID=self.device_id
         )
         self.parental_control_settings = response["json"]
+        if "bedtimeStartingTime" in self.parental_control_settings["playTimerRegulations"]:
+            if self.parental_control_settings["playTimerRegulations"].get("bedtimeStartingTime", {}).get("hour", 0) == 0:
+                self.parental_control_settings["playTimerRegulations"].pop("bedtimeStartingTime")
+
         self.forced_termination_mode = (
             self.parental_control_settings["playTimerRegulations"]["restrictionMode"] == str(RestrictionMode.FORCED_TERMINATION)
         )


### PR DESCRIPTION
I'm not sure if this is intended by Nintendo or not, but suddenly it seems bedtimeStartingTime is no longer valid in the schema, at least when sending updates and this isn't set.

Workaround here to to remove that if the hour is set to 0. The integration does not use this anyway

Fixes: https://github.com/pantherale0/ha-nintendoparentalcontrols/issues/140