### PR TITLE
Refactor bedtime alarm handling and add validation

### DIFF
--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -121,20 +121,20 @@ class Device:
         self._parse_parental_control_setting(response["json"])
         await self._execute_callbacks()
 
-    async def set_bedtime_alarm(self, end_time: time = None, enabled: bool = True):
+    async def set_bedtime_alarm(self, value: time):
         """Update the bedtime alarm for the device."""
-        _LOGGER.debug(">> Device.set_bedtime_alarm(end_time=%s, enabled=%s)",
-                      end_time,
-                      enabled)
+        _LOGGER.debug(">> Device.set_bedtime_alarm(value=%s)",
+                      value)
+        
         bedtime = {
-            "enabled": enabled,
+            "enabled": value.hour != 0 and value.minute != 0,
         }
-        if end_time is not None:
+        if bedtime["enabled"]:
             bedtime = {
                 **bedtime,
                 "endingTime": {
-                    "hour": end_time.hour,
-                    "minute": end_time.minute
+                    "hour": value.hour,
+                    "minute": value.minute
                 }
             }
         if self.timer_mode == "DAILY":

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -8,7 +8,7 @@ from typing import Callable
 
 from .api import Api
 from .const import _LOGGER, DAYS_OF_WEEK
-from .exceptions import HttpException
+from .exceptions import HttpException, BedtimeOutOfRangeError
 from .enum import AlarmSettingState, RestrictionMode
 from .player import Player
 from .utils import is_awaitable
@@ -125,7 +125,12 @@ class Device:
         """Update the bedtime alarm for the device."""
         _LOGGER.debug(">> Device.set_bedtime_alarm(value=%s)",
                       value)
-        
+        if not (
+            (16 <= value.hour <= 22) or
+            (value.hour == 23 and value.minute == 0) or
+            (value.hour == 0 and value.minute == 0)
+        ):
+            raise BedtimeOutOfRangeError(value=value)
         bedtime = {
             "enabled": value.hour != 0 and value.minute != 0,
         }

--- a/pynintendoparental/exceptions.py
+++ b/pynintendoparental/exceptions.py
@@ -1,5 +1,7 @@
 """Nintendo Parental exceptions."""
 
+from datetime import time
+
 class HttpException(Exception):
     """A HTTP error occured"""
     def __init__(self, status_code: int, message: str) -> None:
@@ -19,3 +21,17 @@ class InvalidOAuthConfigurationException(HttpException):
 
 class NoDevicesFoundException(Exception):
     """No devices were found for the account."""
+
+class InputValidationError(Exception):
+    """Input Validation Failed."""
+    value: object
+    error_key: str
+
+class BedtimeOutOfRangeError(InputValidationError):
+    """Bedtime is outside of the allowed range."""
+
+    error_key = "bedtime_alarm_out_of_range"
+
+    def __init__(self, value: object) -> None:
+        super().__init__()
+        self.value = value

--- a/test.py
+++ b/test.py
@@ -2,6 +2,9 @@
 import os
 import logging
 import asyncio
+
+from datetime import time
+
 from dotenv import load_dotenv
 from pynintendoparental import Authenticator, NintendoParental
 from pynintendoparental.exceptions import InvalidSessionTokenException
@@ -36,6 +39,8 @@ async def main():
             _LOGGER.debug("Discovered device %s, label %s", device.device_id, device.name)
             _LOGGER.debug("Usage today %s", device.today_playing_time)
             _LOGGER.debug("Usage remaining %s", device.today_time_remaining)
+            await device.set_bedtime_alarm(time(hour=22, minute=59))
+            await device.set_bedtime_alarm(time(hour=0, minute=0))
 
         _LOGGER.debug("ping")
         await asyncio.sleep(15)


### PR DESCRIPTION
Refactor the `set_bedtime_alarm` method to accept a time value and determine the enabled state based on the provided time. Introduce a `BedtimeOutOfRangeError` exception to enforce bedtime constraints.

For #45