### PR TITLE
Refactor device timer mode handling and add set_timer_mode method

### DIFF
--- a/pynintendoparental/enum.py
+++ b/pynintendoparental/enum.py
@@ -1,6 +1,6 @@
 """Enums"""
 
-from enum import Enum
+from enum import Enum, StrEnum
 
 class AlarmSettingState(Enum):
     """Alarm setting states."""
@@ -17,6 +17,14 @@ class RestrictionMode(Enum):
     """Restriction modes."""
     FORCED_TERMINATION = 0
     ALARM = 1
+
+    def __str__(self) -> str:
+        return self.name
+
+class DeviceTimerMode(StrEnum):
+    """Device timer modes."""
+    DAILY = "DAILY"
+    EACH_DAY_OF_THE_WEEK = "EACH_DAY_OF_THE_WEEK"
 
     def __str__(self) -> str:
         return self.name

--- a/test.py
+++ b/test.py
@@ -8,6 +8,7 @@ from datetime import time
 from dotenv import load_dotenv
 from pynintendoparental import Authenticator, NintendoParental
 from pynintendoparental.exceptions import InvalidSessionTokenException
+from pynintendoparental.enum import DeviceTimerMode
 
 load_dotenv()
 
@@ -39,6 +40,7 @@ async def main():
             _LOGGER.debug("Discovered device %s, label %s", device.device_id, device.name)
             _LOGGER.debug("Usage today %s", device.today_playing_time)
             _LOGGER.debug("Usage remaining %s", device.today_time_remaining)
+            await device.set_timer_mode(DeviceTimerMode.EACH_DAY_OF_THE_WEEK)
 
         _LOGGER.debug("ping")
         await asyncio.sleep(15)


### PR DESCRIPTION
Introduce a new method to set the device's timer mode and refactor existing code to utilize an enum for timer modes, enhancing clarity and maintainability.