### PR TITLE
Add extra playing time attribute to Device class

### DIFF
--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -322,13 +322,10 @@ class Device:
         today_reg = self._get_today_regulation(now)
         limit_time = today_reg.get("timeToPlayInOneDay", {}).get("limitTime")
         self.limit_time = limit_time if limit_time is not None else -1
-        extra_playing_time = pcs["ownedDevice"]["device"]["extraPlayingTime"]
-        if extra_playing_time is None:
-            self.extra_playing_time = None
-        else:
-            self.extra_playing_time = extra_playing_time.get("inOneDay", {}).get(
-                "duration"
-            )
+        extra_playing_time_data = pcs.get("ownedDevice", {}).get("device", {}).get("extraPlayingTime")
+        self.extra_playing_time = None
+        if extra_playing_time_data:
+            self.extra_playing_time = extra_playing_time_data.get("inOneDay", {}).get("duration")
 
         bedtime_setting = today_reg.get("bedtime", {})
         if bedtime_setting.get("enabled"):


### PR DESCRIPTION
Introduce an extra playing time attribute to the Device class to manage additional playtime settings. This change enhances the functionality related to parental controls.