### PR TITLE
Add last_sync property to Device class

### DIFF
--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -67,6 +67,13 @@ class Device:
         """Return the generation."""
         return self.extra.get("platformGeneration", None)
 
+    @property
+    def last_sync(self) -> float | None:
+        """Return the last time this device was synced."""
+        return self.extra.get("synchronizedParentalControlSetting", {}).get(
+            "synchronizedAt", None
+        )
+
     async def update(self):
         """Update data."""
         _LOGGER.debug(">> Device.update()")

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -22,6 +22,16 @@ async def test_device_parsing(mock_api: Api, snapshot: SnapshotAssertion):
 
     mock_api.async_get_device_monthly_summary.assert_called_once()
 
+    test_device = copy.deepcopy(device)
+    assert test_device.last_sync is not None
+    assert test_device.last_sync == device.extra["synchronizedParentalControlSetting"][
+        "synchronizedAt"
+    ]
+    del test_device.extra["synchronizedParentalControlSetting"]["synchronizedAt"]
+    assert test_device.last_sync is None
+    del test_device.extra["synchronizedParentalControlSetting"]
+    assert test_device.last_sync is None
+
     assert clean_device_for_snapshot(device) == snapshot(
         exclude=props("today_time_remaining")
     )


### PR DESCRIPTION
Introduce a `last_sync` property to the Device class to track the last synchronization time, along with corresponding tests to validate its functionality.