### PR TITLE
Fix HTTP 400 error on update restriction level calls

### DIFF
--- a/pynintendoparental/api.py
+++ b/pynintendoparental/api.py
@@ -151,19 +151,16 @@ class Api:
         self, device_id: str, parental_control_setting: dict
     ) -> dict:
         """Update device restriction level."""
+        allowed_keys = (
+            "vrRestrictionEtag",
+            "whitelistedApplicationList",
+            "functionalRestrictionLevel",
+            "parentalControlSettingEtag",
+        )
         settings = {
             "deviceId": device_id,
             "customSettings": parental_control_setting.get("customSettings", {}),
-            "vrRestrictionEtag": parental_control_setting.get("vrRestrictionEtag"),
-            "whitelistedApplicationList": parental_control_setting.get(
-                "whitelistedApplicationList"
-            ),
-            "functionalRestrictionLevel": parental_control_setting.get(
-                "functionalRestrictionLevel"
-            ),
-            "parentalControlSettingEtag": parental_control_setting.get(
-                "parentalControlSettingEtag"
-            ),
+            **{key: parental_control_setting.get(key) for key in allowed_keys},
         }
         return await self.send_request(
             endpoint="update_restriction_level", body=settings

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -172,7 +172,14 @@ async def test_api_methods(mock_authenticator: Authenticator):
     await api.async_update_restriction_level("DEVICE_ID", {"some": "setting"})
     api.send_request.assert_called_with(
         endpoint="update_restriction_level",
-        body={"deviceId": "DEVICE_ID", 'customSettings': {}, 'vrRestrictionEtag': None, 'whitelistedApplicationList': None, 'functionalRestrictionLevel': None, 'parentalControlSettingEtag': None},
+        body={
+            "deviceId": "DEVICE_ID",
+            "customSettings": {},
+            "vrRestrictionEtag": None,
+            "whitelistedApplicationList": None,
+            "functionalRestrictionLevel": None,
+            "parentalControlSettingEtag": None
+        },
     )
 
     await api.async_update_extra_playing_time("DEVICE_ID", -1)


### PR DESCRIPTION
Fixes:

```
pynintendoauth.exceptions.HttpException: HTTP 400: Unrecognized field "unlockCode" (class com.nintendo.nx.moon.api.v2.handler.UpdateRestrictionLevelRequest), not marked as ignorable (6 known properties: "deviceId", "customSettings", "vrRestrictionEtag", "whitelistedApplicationList", "functionalRestrictionLevel", "parentalControlSettingEtag"])
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 46] (through reference chain: com.nintendo.nx.moon.api.v2.handler.UpdateRestrictionLevelRequest["unlockCode"]) (invalid_params)
```