### PR TITLE
fix(device): replace updateExtraPlayingTime with confirmExtraPlayingTime

### DIFF
--- a/pynintendoparental/api.py
+++ b/pynintendoparental/api.py
@@ -170,14 +170,20 @@ class Api:
             body={"deviceId": device_id, "unlockCode": str(new_code)},
         )
 
-    async def async_update_extra_playing_time(self, device_id: str, additional_time: int) -> dict:
-        """Update device extra playing time."""
+    async def async_confirm_extra_playing_time(
+        self, device_id: str, additional_time: int, with_bedtime: bool
+    ) -> dict:
+        """Confirm (grant) extra playing time for the current day.
+
+        Args:
+            device_id: The Nintendo device ID.
+            additional_time: Number of additional minutes to grant.
+            with_bedtime: When True, the bonus is granted relative to the
+                bedtime limit; when False it extends the inOneDay play limit.
+        """
         body = {
             "deviceId": device_id,
             "additionalTime": additional_time,
-            "status": "TO_ADDED",
+            "withBedtime": with_bedtime,
         }
-        if additional_time == -1:
-            body["status"] = "TO_INFINITY"
-            body.pop("additionalTime")
-        return await self.send_request(endpoint="update_extra_playing_time", body=body)
+        return await self.send_request(endpoint="confirm_extra_playing_time", body=body)

--- a/pynintendoparental/const.py
+++ b/pynintendoparental/const.py
@@ -43,7 +43,7 @@ ENDPOINTS = {
         "method": "GET",
     },
     "get_device_parental_control_setting": {
-        "url": "{BASE_URL}/v2/actions/parentalControlSetting/fetchParentalControlSetting?deviceId={DEVICE_ID}",
+        "url": "{BASE_URL}/v3/actions/parentalControlSetting/fetchParentalControlSetting?deviceId={DEVICE_ID}",
         "method": "GET",
     },
     "update_restriction_level": {
@@ -64,8 +64,8 @@ ENDPOINTS = {
         ),
         "method": "GET",
     },
-    "update_extra_playing_time": {
-        "url": "{BASE_URL}/v2/actions/device/updateExtraPlayingTime",
+    "confirm_extra_playing_time": {
+        "url": "{BASE_URL}/v2/actions/device/confirmExtraPlayingTime",
         "method": "POST",
     },
 }

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -649,7 +649,8 @@ class Device:
                     )
                     original_minutes = self.bedtime_alarm.hour * 60 + self.bedtime_alarm.minute
                     extended_minutes = extended_bedtime.hour * 60 + extended_bedtime.minute
-                    self.extra_playing_time = extended_minutes - original_minutes
+                    # Normalize to handle midnight-wrap (e.g. 23:30 → 00:15 = +45 min)
+                    self.extra_playing_time = (extended_minutes - original_minutes) % 1440
                     self.bedtime_alarm = extended_bedtime
         if bedtime_setting.get("enabled") and bedtime_setting["startingTime"]:
             self.bedtime_end = time(

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -713,9 +713,11 @@ class Device:
                 bedtime_dt = datetime.combine(now.date(), self.bedtime_alarm)
                 # If the bedtime clock value is in early-morning hours (00:00–05:59) it
                 # can only occur when the bedtime was extended past midnight.  In that
-                # case combine() produced a datetime that is earlier than now, so roll
-                # it forward by one day to get the correct future instant.
-                if bedtime_dt <= now and self.bedtime_alarm.hour < 6:
+                # case combine() produced a datetime that is earlier than now; roll it
+                # forward by one day — but only when now is still in the evening
+                # (hour >= 18) so we don't incorrectly roll forward when now is already
+                # past the early-morning bedtime (e.g. now=01:00, bedtime=00:15).
+                if bedtime_dt <= now and self.bedtime_alarm.hour < 6 and now.hour >= 18:
                     bedtime_dt += timedelta(days=1)
                 if bedtime_dt > now:  # Bedtime is in the future today (or next day)
                     time_remaining_by_bedtime = (bedtime_dt - now).total_seconds() / 60

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -216,7 +216,7 @@ class Device:
         for the current day only. The extra time does not carry over to other days.
 
         Args:
-            minutes: Number of additional minutes to add (must be positive).
+            minutes: Number of additional minutes to add.
 
         Example:
             ```python
@@ -711,7 +711,13 @@ class Device:
             # 2. Calculate remaining time until bedtime
             if self.bedtime_alarm and self.bedtime_alarm != time(hour=0, minute=0) and self.alarms_enabled:
                 bedtime_dt = datetime.combine(now.date(), self.bedtime_alarm)
-                if bedtime_dt > now:  # Bedtime is in the future today
+                # If the bedtime clock value is in early-morning hours (00:00–05:59) it
+                # can only occur when the bedtime was extended past midnight.  In that
+                # case combine() produced a datetime that is earlier than now, so roll
+                # it forward by one day to get the correct future instant.
+                if bedtime_dt <= now and self.bedtime_alarm.hour < 6:
+                    bedtime_dt += timedelta(days=1)
+                if bedtime_dt > now:  # Bedtime is in the future today (or next day)
                     time_remaining_by_bedtime = (bedtime_dt - now).total_seconds() / 60
                 else:  # Bedtime has passed
                     time_remaining_by_bedtime = 0.0

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -224,8 +224,12 @@ class Device:
             ```
         """
         _LOGGER.debug(">> Device.add_extra_time(minutes=%s)", minutes)
-        # This endpoint does not return parental control settings, so we call it directly.
-        await self._api.async_update_extra_playing_time(self.device_id, minutes)
+        with_bedtime = (
+            self.bedtime_alarm is not None
+            and self.bedtime_alarm != time(hour=0, minute=0)
+            and self.alarms_enabled
+        )
+        await self._api.async_confirm_extra_playing_time(self.device_id, minutes, with_bedtime)
         await self._get_parental_control_setting(datetime.now())
 
     async def set_restriction_mode(self, mode: RestrictionMode):
@@ -627,29 +631,26 @@ class Device:
         else:
             self.bedtime_alarm = time(hour=0, minute=0)
 
-        # Parse extra playing time based on whether bedtime is enabled
+        # Parse extra playing time: prefer inOneDay.duration when available,
+        # fall back to bedtime extension calculation otherwise.
         extra_playing_time_data = pcs.get("ownedDevice", {}).get("device", {}).get("extraPlayingTime")
         self.extra_playing_time = None
         if extra_playing_time_data is not None:
-            if bedtime_enabled and extra_playing_time_data.get("bedtime"):
-                # When bedtime is enabled, calculate the difference between new bedtime and original bedtime
+            in_one_day = extra_playing_time_data.get("inOneDay")
+            if in_one_day is not None:
+                self.extra_playing_time = in_one_day.get("duration")
+            elif bedtime_enabled and extra_playing_time_data.get("bedtime"):
+                # Fall back to bedtime extension when inOneDay is not present
                 extended_bedtime_data = extra_playing_time_data.get("bedtime", {}).get("endTime")
                 if extended_bedtime_data:
                     extended_bedtime = time(
                         hour=extended_bedtime_data["hour"],
                         minute=extended_bedtime_data["minute"],
                     )
-                    # Calculate difference in minutes
                     original_minutes = self.bedtime_alarm.hour * 60 + self.bedtime_alarm.minute
                     extended_minutes = extended_bedtime.hour * 60 + extended_bedtime.minute
                     self.extra_playing_time = extended_minutes - original_minutes
-                    # Update bedtime_alarm to the extended bedtime
                     self.bedtime_alarm = extended_bedtime
-            else:
-                # When bedtime is disabled, use inOneDay duration
-                in_one_day = extra_playing_time_data.get("inOneDay")
-                if in_one_day is not None:
-                    self.extra_playing_time = in_one_day.get("duration")
         if bedtime_setting.get("enabled") and bedtime_setting["startingTime"]:
             self.bedtime_end = time(
                 hour=bedtime_setting["startingTime"]["hour"],

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -714,10 +714,11 @@ class Device:
                 # If the bedtime clock value is in early-morning hours (00:00–05:59) it
                 # can only occur when the bedtime was extended past midnight.  In that
                 # case combine() produced a datetime that is earlier than now; roll it
-                # forward by one day — but only when now is still in the evening
-                # (hour >= 18) so we don't incorrectly roll forward when now is already
-                # past the early-morning bedtime (e.g. now=01:00, bedtime=00:15).
-                if bedtime_dt <= now and self.bedtime_alarm.hour < 6 and now.hour >= 18:
+                # forward by one day so the next-day occurrence is used — but skip the
+                # rollover when now is still in the early-morning window (hour < 6)
+                # because the bedtime may have just passed this morning
+                # (e.g. now=01:00, bedtime=00:15 → bedtime already elapsed → 0).
+                if bedtime_dt <= now and self.bedtime_alarm.hour < 6 and now.hour >= 6:
                     bedtime_dt += timedelta(days=1)
                 if bedtime_dt > now:  # Bedtime is in the future today (or next day)
                     time_remaining_by_bedtime = (bedtime_dt - now).total_seconds() / 60

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -633,24 +633,28 @@ class Device:
 
         # Parse extra playing time: prefer inOneDay.duration when available,
         # fall back to bedtime extension calculation otherwise.
+        # Always update bedtime_alarm when bedtime is extended so that
+        # _calculate_today_remaining_time uses the correct extended bedtime.
         extra_playing_time_data = pcs.get("ownedDevice", {}).get("device", {}).get("extraPlayingTime")
         self.extra_playing_time = None
         if extra_playing_time_data is not None:
             in_one_day = extra_playing_time_data.get("inOneDay")
             if in_one_day is not None:
                 self.extra_playing_time = in_one_day.get("duration")
-            elif bedtime_enabled and extra_playing_time_data.get("bedtime"):
-                # Fall back to bedtime extension when inOneDay is not present
+            if bedtime_enabled and extra_playing_time_data.get("bedtime"):
                 extended_bedtime_data = extra_playing_time_data.get("bedtime", {}).get("endTime")
                 if extended_bedtime_data:
                     extended_bedtime = time(
                         hour=extended_bedtime_data["hour"],
                         minute=extended_bedtime_data["minute"],
                     )
-                    original_minutes = self.bedtime_alarm.hour * 60 + self.bedtime_alarm.minute
-                    extended_minutes = extended_bedtime.hour * 60 + extended_bedtime.minute
-                    # Normalize to handle midnight-wrap (e.g. 23:30 → 00:15 = +45 min)
-                    self.extra_playing_time = (extended_minutes - original_minutes) % 1440
+                    if self.extra_playing_time is None:
+                        # inOneDay not available — derive extra time from bedtime extension
+                        original_minutes = self.bedtime_alarm.hour * 60 + self.bedtime_alarm.minute
+                        extended_minutes = extended_bedtime.hour * 60 + extended_bedtime.minute
+                        # Normalize to handle midnight-wrap (e.g. 23:30 → 00:15 = +45 min)
+                        self.extra_playing_time = (extended_minutes - original_minutes) % 1440
+                    # Always update bedtime_alarm to the extended bedtime
                     self.bedtime_alarm = extended_bedtime
         if bedtime_setting.get("enabled") and bedtime_setting["startingTime"]:
             self.bedtime_end = time(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -162,16 +162,16 @@ async def test_api_methods(mock_authenticator: Authenticator):
         },
     )
 
-    await api.async_update_extra_playing_time("DEVICE_ID", -1)
+    await api.async_confirm_extra_playing_time("DEVICE_ID", 15, False)
     api.send_request.assert_called_with(
-        endpoint="update_extra_playing_time",
-        body={"deviceId": "DEVICE_ID", "status": "TO_INFINITY"},
+        endpoint="confirm_extra_playing_time",
+        body={"deviceId": "DEVICE_ID", "additionalTime": 15, "withBedtime": False},
     )
 
-    await api.async_update_extra_playing_time("DEVICE_ID", 60)
+    await api.async_confirm_extra_playing_time("DEVICE_ID", 30, True)
     api.send_request.assert_called_with(
-        endpoint="update_extra_playing_time",
-        body={"deviceId": "DEVICE_ID", "additionalTime": 60, "status": "TO_ADDED"},
+        endpoint="confirm_extra_playing_time",
+        body={"deviceId": "DEVICE_ID", "additionalTime": 30, "withBedtime": True},
     )
 
     await api.async_update_play_timer("DEVICE_ID", {"some": "setting"})

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -570,10 +570,11 @@ async def test_add_extra_time(
     assert len(devices) > 0
     device = devices[0]
 
-    mock_api.async_update_extra_playing_time.return_value = None
+    mock_api.async_confirm_extra_playing_time.return_value = None
 
     await device.add_extra_time(extra_time)
-    mock_api.async_update_extra_playing_time.assert_called_with(device.device_id, extra_time)
+    # bedtime_alarm is None (no parental control settings loaded), so with_bedtime=False
+    mock_api.async_confirm_extra_playing_time.assert_called_with(device.device_id, extra_time, False)
     assert f">> Device.add_extra_time(minutes={extra_time})" in caplog.text
 
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -748,6 +748,38 @@ async def test_parse_with_extra_playing_time_bedtime_enabled(mock_api: Api):
     assert device.bedtime_alarm == time(hour=21, minute=30)
 
 
+async def test_parse_with_extra_playing_time_bedtime_midnight_wrap(mock_api: Api):
+    """Test that extra_playing_time normalises correctly when extended bedtime wraps past midnight."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    assert len(devices) > 0
+    device = devices[0]
+
+    pcs_response = await load_fixture("device_parental_control_setting")
+
+    # Original bedtime ending at 23:30
+    pcs_response["parentalControlSetting"]["playTimerRegulations"]["dailyRegulations"]["bedtime"] = {
+        "enabled": True,
+        "endingTime": {"hour": 23, "minute": 30},
+        "startingTime": {"hour": 6, "minute": 0},
+    }
+
+    # Extended bedtime wraps past midnight to 00:15
+    # Without % 1440 normalisation the delta would be negative: 15 - 1410 = -1395
+    pcs_response["ownedDevice"]["device"]["extraPlayingTime"] = {
+        "bedtime": {"endTime": {"hour": 0, "minute": 15}},
+        "inOneDay": None,
+        "expiresAt": 1770335999,
+    }
+
+    mock_api.async_get_device_parental_control_setting.return_value = {"json": pcs_response}
+    await device.update()
+
+    # 23:30 → 00:15 wraps to +45 minutes, not -1395
+    assert device.extra_playing_time == 45
+    assert device.bedtime_alarm == time(hour=0, minute=15)
+
+
 async def test_today_time_remaining_with_extra_playing_time(mock_api: Api):
     """Test that today_time_remaining accounts for extra_playing_time."""
     devices_response = await load_fixture("account_devices")
@@ -811,6 +843,49 @@ async def test_today_time_remaining_with_extra_playing_time(mock_api: Api):
     expected_remaining = min(remaining_by_play_limit, remaining_by_end_of_day)
 
     assert device.today_time_remaining == expected_remaining
+
+
+async def test_bedtime_rollover_evening(mock_api: Api):
+    """Test that a midnight-wrap bedtime is correctly rolled to the next day when now is in the evening."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    # Directly configure the device state: bedtime extended past midnight to 00:15
+    device.bedtime_alarm = time(hour=0, minute=15)
+    device.alarms_enabled = True
+    # Use a large play limit (480 min) so that the bedtime constraint (75 min) is binding
+    device.limit_time = 480
+    device.today_playing_time = 0
+
+    # now = 23:00 in the evening — bedtime 00:15 is 75 min away (after rollover to next day)
+    now_evening = datetime.now().replace(hour=23, minute=0, second=0, microsecond=0)
+    device._calculate_today_remaining_time(now_evening)
+
+    # Bedtime constraint: 00:15 tomorrow - 23:00 today = 75 min
+    # Play-limit constraint: 480 - 0 = 480 min
+    # effective_remaining = min(75, 480) = 75
+    assert device.today_time_remaining == 75
+
+
+async def test_bedtime_rollover_after_midnight(mock_api: Api):
+    """Test that a midnight-wrap bedtime is NOT rolled when now is already past it (e.g. 01:00)."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    # bedtime was extended past midnight to 00:15; it's now 01:00 — bedtime already passed
+    device.bedtime_alarm = time(hour=0, minute=15)
+    device.alarms_enabled = True
+    device.limit_time = 480
+    device.today_playing_time = 0
+
+    now_after_midnight = datetime.now().replace(hour=1, minute=0, second=0, microsecond=0)
+    device._calculate_today_remaining_time(now_after_midnight)
+
+    # now.hour=1 < 18 → no rollover; bedtime_dt=today 00:15 < now 01:00 → bedtime passed
+    # time_remaining_by_bedtime = 0 → effective_remaining = min(480, 0) = 0
+    assert device.today_time_remaining == 0
 
 
 async def test_calculate_times(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -573,7 +573,8 @@ async def test_add_extra_time(
     mock_api.async_confirm_extra_playing_time.return_value = None
 
     await device.add_extra_time(extra_time)
-    # bedtime_alarm is None (no parental control settings loaded), so with_bedtime=False
+    # bedtime is disabled in the fixture (bedtime.enabled=false), so bedtime_alarm is
+    # time(0, 0) after update() runs; the != time(0, 0) check makes with_bedtime=False
     mock_api.async_confirm_extra_playing_time.assert_called_with(device.device_id, extra_time, False)
     assert f">> Device.add_extra_time(minutes={extra_time})" in caplog.text
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -868,8 +868,29 @@ async def test_bedtime_rollover_evening(mock_api: Api):
     assert device.today_time_remaining == 75
 
 
+async def test_bedtime_rollover_daytime(mock_api: Api):
+    """Test that a midnight-wrap bedtime is rolled to next day even during daytime hours."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    device.bedtime_alarm = time(hour=0, minute=15)
+    device.alarms_enabled = True
+    device.limit_time = 480
+    device.today_playing_time = 0
+
+    # now = 12:00 noon — bedtime 00:15 is 12h15m = 735 min away after rollover
+    now_noon = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
+    device._calculate_today_remaining_time(now_noon)
+
+    # now.hour=12 >= 6 → rollover applied; bedtime is 12*60+15 = 735 min from noon
+    # Play-limit constraint: 480 - 0 = 480 min (more restrictive)
+    # effective_remaining = min(735, 480) = 480
+    assert device.today_time_remaining == 480
+
+
 async def test_bedtime_rollover_after_midnight(mock_api: Api):
-    """Test that a midnight-wrap bedtime is NOT rolled when now is already past it (e.g. 01:00)."""
+    """Test that a midnight-wrap bedtime is NOT rolled when now is in the early-morning window."""
     devices_response = await load_fixture("account_devices")
     devices = await Device.from_devices_response(devices_response, mock_api)
     device = devices[0]
@@ -883,7 +904,7 @@ async def test_bedtime_rollover_after_midnight(mock_api: Api):
     now_after_midnight = datetime.now().replace(hour=1, minute=0, second=0, microsecond=0)
     device._calculate_today_remaining_time(now_after_midnight)
 
-    # now.hour=1 < 18 → no rollover; bedtime_dt=today 00:15 < now 01:00 → bedtime passed
+    # now.hour=1 < 6 → no rollover; bedtime_dt=today 00:15 < now 01:00 → bedtime passed
     # time_remaining_by_bedtime = 0 → effective_remaining = min(480, 0) = 0
     assert device.today_time_remaining == 0
 


### PR DESCRIPTION
Resolves #114

## Problem

`add_extra_time()` called `updateExtraPlayingTime` with `status=TO_ADDED`. This endpoint returns HTTP 200 but has no effect — Nintendo queues the request and never applies it, so the extra playing time never shows up in the app or in `fetchParentalControlSetting`.

## Root cause

Discovered by decompiling the official Nintendo Switch Parental Controls app (`com.nintendo.znma` v2.4.0) with jadx.

The app never calls `updateExtraPlayingTime`. It calls `confirmExtraPlayingTime` directly:

```
POST /v2/actions/device/confirmExtraPlayingTime
{
  "deviceId": "...",
  "additionalTime": 15,
  "withBedtime": true
}
```

The `withBedtime` flag controls whether the bonus extends the bedtime or the inOneDay play limit. The app derives it from whether the device has an active bedtime alarm.

Additionally, the app calls `fetchParentalControlSetting` at `/v3/`, not `/v2/`.

## Changes

- **`const.py`**: replace `update_extra_playing_time` endpoint with `confirm_extra_playing_time`; upgrade `fetchParentalControlSetting` from v2 to v3
- **`api.py`**: replace `async_update_extra_playing_time` with `async_confirm_extra_playing_time(device_id, additional_time, with_bedtime)`
- **`device.py`**:
  - Update `add_extra_time` to call the new method, deriving `with_bedtime` from `bedtime_alarm` and `alarms_enabled`
  - Fix extra playing time parsing to prefer `inOneDay.duration` (always accurate); always update `bedtime_alarm` to the extended value so `_calculate_today_remaining_time` uses the correct bedtime constraint
  - Normalize the bedtime-extension fallback delta with `% 1440` to handle cases where extended bedtime wraps past midnight (e.g. 23:30 → 00:15 = +45 min, not -1395)
  - Fix `_calculate_today_remaining_time` to roll a midnight-wrap bedtime forward one day when `now` is outside the early-morning window (`now.hour >= 6`), preventing remaining time from incorrectly clamping to 0 during daytime and evening
- **`tests/`**: update `test_add_extra_time` and `test_api.py` to assert the new endpoint and payload; add tests for the midnight-wrap normalization and the bedtime rollover (both branches)

## Tested

Verified on a live Nintendo Switch with `EACH_DAY_OF_THE_WEEK` timer mode and bedtime enabled. `add_extra_time(15)` now correctly applies the bonus time and updates `extra_playing_time` and `today_time_remaining` in Home Assistant.