### PR TITLE
Add cancel_extra_time, guard playtime edits while active, and batch requests over 60 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,11 @@ All methods are asynchronous.
 - `add_device_callback(callback)`: Adds a callback that will be called when the device state changes.
 - `remove_device_callback(callback)`: Removes a previously added callback.
 - `set_new_pin(pin: str)`: Sets a new PIN for the parental controls.
-- `add_extra_time(minutes: int)`: Adds extra playing time for the current day.
+- `add_extra_time(minutes: int)`: Adds extra playing time for the current day. Requests over 60 minutes are
+  transparently split into multiple calls (Nintendo's server rejects more than 60 minutes per call). Use `-1`
+  for unlimited time for the rest of the day.
+- `cancel_extra_time()`: Cancels any active extra playing time for the current day. Required before changing
+  the daily limit, per-day restrictions, timer mode, restriction mode, or bedtime while extra time is active.
 - `update_max_daily_playtime(minutes: int)`: Sets the daily playtime limit. Use `-1` to remove the limit.
 - `set_restriction_mode(mode: RestrictionMode)`: Sets the restriction mode.
     - `RestrictionMode.FORCED_TERMINATION`: The software will be suspended when the playtime limit is reached.

--- a/pynintendoparental/api.py
+++ b/pynintendoparental/api.py
@@ -170,9 +170,7 @@ class Api:
             body={"deviceId": device_id, "unlockCode": str(new_code)},
         )
 
-    async def async_confirm_extra_playing_time(
-        self, device_id: str, additional_time: int, with_bedtime: bool
-    ) -> dict:
+    async def async_confirm_extra_playing_time(self, device_id: str, additional_time: int, with_bedtime: bool) -> dict:
         """Confirm (grant) extra playing time for the current day.
 
         Args:
@@ -198,4 +196,9 @@ class Api:
         if additional_time == -1:
             body["status"] = "TO_INFINITY"
             body.pop("additionalTime")
+        return await self.send_request(endpoint="update_extra_playing_time", body=body)
+
+    async def async_cancel_extra_playing_time(self, device_id: str) -> dict:
+        """Cancel any active extra playing time for the current day."""
+        body = {"deviceId": device_id, "status": "TO_CANCELED"}
         return await self.send_request(endpoint="update_extra_playing_time", body=body)

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -19,10 +19,38 @@ from .enum import (
 from .exceptions import (
     BedtimeOutOfRangeError,
     DailyPlaytimeOutOfRangeError,
+    ExtraPlayingTimeActiveError,
     InvalidDeviceStateError,
 )
 from .player import Player
 from .utils import is_awaitable
+
+# Nintendo's server hard-rejects additionalTime > 60 on a single
+# updateExtraPlayingTime/confirmExtraPlayingTime call (HTTP 400:
+# "additionalTime must be less than or equal to 60"), matching the app's own
+# largest bonus-time preset (ONE_HOUR). Requests above this are split into
+# multiple calls.
+_MAX_EXTRA_TIME_MINUTES_PER_CALL = 60
+# Paced between batched calls rather than fired back-to-back, since the
+# server appears to need a moment to settle each write before the next one
+# (and to avoid hammering the API).
+_EXTRA_TIME_BATCH_DELAY_SECONDS = 2
+
+
+def _split_extra_time(minutes: int) -> list[int]:
+    """Split a requested extra-time amount into <=60-minute chunks.
+
+    -1 (unlimited/TO_INFINITY) is never split, regardless of size.
+    """
+    if minutes == -1 or minutes <= _MAX_EXTRA_TIME_MINUTES_PER_CALL:
+        return [minutes]
+    chunks = []
+    remaining = minutes
+    while remaining > 0:
+        chunk = min(remaining, _MAX_EXTRA_TIME_MINUTES_PER_CALL)
+        chunks.append(chunk)
+        remaining -= chunk
+    return chunks
 
 
 class Device:
@@ -217,25 +245,68 @@ class Device:
         This grants additional playing time beyond the configured daily limit
         for the current day only. The extra time does not carry over to other days.
 
+        Nintendo's server rejects more than 60 minutes in a single request, so
+        larger amounts are transparently split into multiple <=60-minute
+        calls, paced a couple of seconds apart. `-1` (unlimited) is always a
+        single call regardless of size. Each chunk re-evaluates whether
+        bedtime is active from freshly-fetched state, so a bedtime change
+        mid-batch is picked up for the remaining chunks. If a chunk's API
+        call raises partway through, earlier chunks remain applied - check
+        `extra_playing_time` afterward to see how much actually went through.
+
         Args:
-            minutes: Number of additional minutes to add (must be positive).
+            minutes: Number of additional minutes to add (must be positive), or
+                -1 to grant unlimited time for the rest of the day.
 
         Example:
             ```python
-            await device.add_extra_time(30)  # Add 30 minutes
+            await device.add_extra_time(30)   # Add 30 minutes
+            await device.add_extra_time(130)  # Add 130 minutes, batched as 60+60+10
             ```
         """
         _LOGGER.debug(">> Device.add_extra_time(minutes=%s)", minutes)
-        with_bedtime = (
-            self.bedtime_alarm is not None
-            and self.bedtime_alarm != time(hour=0, minute=0)
-            and self.alarms_enabled
-        )
-        if minutes != -1 and with_bedtime:
-            await self._api.async_confirm_extra_playing_time(self.device_id, minutes, True)
-        else:
-            await self._api.async_update_extra_playing_time(self.device_id, minutes)
+        chunks = _split_extra_time(minutes)
+        for index, chunk in enumerate(chunks):
+            with_bedtime = (
+                self.bedtime_alarm is not None and self.bedtime_alarm != time(hour=0, minute=0) and self.alarms_enabled
+            )
+            if chunk != -1 and with_bedtime:
+                await self._api.async_confirm_extra_playing_time(self.device_id, chunk, True)
+            else:
+                await self._api.async_update_extra_playing_time(self.device_id, chunk)
+            await self._get_parental_control_setting(datetime.now())
+            if index < len(chunks) - 1:
+                await asyncio.sleep(_EXTRA_TIME_BATCH_DELAY_SECONDS)
+        await self._execute_callbacks()
+
+    async def cancel_extra_time(self):
+        """Cancel any active extra playing time for the current day.
+
+        Nintendo's own app requires this before the daily limit, per-day
+        restrictions, timer mode, or bedtime can be changed while extra time
+        is active (see `Device.update_max_daily_playtime` and friends).
+
+        Example:
+            ```python
+            await device.cancel_extra_time()
+            ```
+        """
+        _LOGGER.debug(">> Device.cancel_extra_time()")
+        await self._api.async_cancel_extra_playing_time(self.device_id)
         await self._get_parental_control_setting(datetime.now())
+        await self._execute_callbacks()
+
+    def _raise_if_extra_time_active(self, action: str):
+        """Raise if extra playing time is active; Nintendo blocks playtime/bedtime edits until it's cancelled.
+
+        Checks `extra_playing_time_unlimited` via getattr because it's
+        introduced by a separate, standalone PR (the isInfinity parsing fix)
+        that may land before or after this one - this stays correct either way.
+        """
+        if self.extra_playing_time is not None or getattr(self, "extra_playing_time_unlimited", False):
+            raise ExtraPlayingTimeActiveError(
+                f"Cannot {action} while extra playing time is active. Call cancel_extra_time() first."
+            )
 
     async def set_restriction_mode(self, mode: RestrictionMode):
         """Set the restriction mode for playtime limits.
@@ -251,8 +322,12 @@ class Device:
 
             await device.set_restriction_mode(RestrictionMode.FORCED_TERMINATION)
             ```
+
+        Raises:
+            ExtraPlayingTimeActiveError: If extra playing time is currently active.
         """
         _LOGGER.debug(">> Device.set_restriction_mode(mode=%s)", mode)
+        self._raise_if_extra_time_active("change the restriction mode")
         self.parental_control_settings["playTimerRegulations"]["restrictionMode"] = str(mode)
         response = await self._api.async_update_play_timer(
             self.device_id,
@@ -273,6 +348,7 @@ class Device:
 
         Raises:
             BedtimeOutOfRangeError: If the time is outside the valid range.
+            ExtraPlayingTimeActiveError: If extra playing time is currently active.
 
         Example:
             ```python
@@ -283,6 +359,7 @@ class Device:
             ```
         """
         _LOGGER.debug(">> Device.set_bedtime_alarm(value=%s)", value)
+        self._raise_if_extra_time_active("change the bedtime alarm")
         if not ((16 <= value.hour <= 23) or (value.hour == 0 and value.minute == 0)):
             raise BedtimeOutOfRangeError(value=value)
         now = datetime.now()
@@ -328,6 +405,7 @@ class Device:
 
         Raises:
             BedtimeOutOfRangeError: If the time is outside the valid range.
+            ExtraPlayingTimeActiveError: If extra playing time is currently active.
 
         Example:
             ```python
@@ -338,6 +416,7 @@ class Device:
             ```
         """
         _LOGGER.debug(">> Device.set_bedtime_end_time(value=%s)", value)
+        self._raise_if_extra_time_active("change the bedtime end time")
         if not time(5, 0) <= value <= time(9, 0) and value != time(0, 0):
             raise BedtimeOutOfRangeError(value=value)
         now = datetime.now()
@@ -381,8 +460,12 @@ class Device:
 
             await device.set_timer_mode(DeviceTimerMode.DAILY)
             ```
+
+        Raises:
+            ExtraPlayingTimeActiveError: If extra playing time is currently active.
         """
         _LOGGER.debug(">> Device.set_timer_mode(mode=%s)", mode)
+        self._raise_if_extra_time_active("change the timer mode")
         self.timer_mode = mode
         self.parental_control_settings["playTimerRegulations"]["timerMode"] = str(mode)
         await self._send_api_update(
@@ -416,6 +499,7 @@ class Device:
             InvalidDeviceStateError: If timer_mode is not EACH_DAY_OF_THE_WEEK.
             ValueError: If day_of_week is invalid.
             BedtimeOutOfRangeError: If bedtime values are outside valid ranges.
+            ExtraPlayingTimeActiveError: If extra playing time is currently active.
 
         Example:
             ```python
@@ -442,6 +526,7 @@ class Device:
             bedtime_end,
             max_daily_playtime,
         )
+        self._raise_if_extra_time_active("change daily restrictions")
         if self.timer_mode != DeviceTimerMode.EACH_DAY_OF_THE_WEEK:
             raise InvalidDeviceStateError("Daily restrictions can only be set when timer_mode is EACH_DAY_OF_THE_WEEK.")
         if day_of_week not in DAYS_OF_WEEK:
@@ -529,6 +614,7 @@ class Device:
 
         Raises:
             DailyPlaytimeOutOfRangeError: If minutes is outside the valid range.
+            ExtraPlayingTimeActiveError: If extra playing time is currently active.
 
         Example:
             ```python
@@ -537,6 +623,7 @@ class Device:
             ```
         """
         _LOGGER.debug(">> Device.update_max_daily_playtime(minutes=%s)", minutes)
+        self._raise_if_extra_time_active("change the daily playtime limit")
         if isinstance(minutes, float):
             minutes = int(minutes)
         if not (-1 <= minutes <= 360):

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -258,6 +258,9 @@ class Device:
             minutes: Number of additional minutes to add (must be positive), or
                 -1 to grant unlimited time for the rest of the day.
 
+        Raises:
+            ValueError: If minutes is less than -1.
+
         Example:
             ```python
             await device.add_extra_time(30)   # Add 30 minutes
@@ -265,19 +268,27 @@ class Device:
             ```
         """
         _LOGGER.debug(">> Device.add_extra_time(minutes=%s)", minutes)
+        if isinstance(minutes, float):
+            minutes = int(minutes)
+        if minutes < -1:
+            raise ValueError("minutes must be -1 or a non-negative integer.")
         chunks = _split_extra_time(minutes)
-        for index, chunk in enumerate(chunks):
-            with_bedtime = (
-                self.bedtime_alarm is not None and self.bedtime_alarm != time(hour=0, minute=0) and self.alarms_enabled
-            )
-            if chunk != -1 and with_bedtime:
-                await self._api.async_confirm_extra_playing_time(self.device_id, chunk, True)
-            else:
-                await self._api.async_update_extra_playing_time(self.device_id, chunk)
-            await self._get_parental_control_setting(datetime.now())
-            if index < len(chunks) - 1:
-                await asyncio.sleep(_EXTRA_TIME_BATCH_DELAY_SECONDS)
-        await self._execute_callbacks()
+        try:
+            for index, chunk in enumerate(chunks):
+                with_bedtime = (
+                    self.bedtime_alarm is not None
+                    and self.bedtime_alarm != time(hour=0, minute=0)
+                    and self.alarms_enabled
+                )
+                if chunk != -1 and with_bedtime:
+                    await self._api.async_confirm_extra_playing_time(self.device_id, chunk, True)
+                else:
+                    await self._api.async_update_extra_playing_time(self.device_id, chunk)
+                await self._get_parental_control_setting(datetime.now())
+                if index < len(chunks) - 1:
+                    await asyncio.sleep(_EXTRA_TIME_BATCH_DELAY_SECONDS)
+        finally:
+            await self._execute_callbacks()
 
     async def cancel_extra_time(self):
         """Cancel any active extra playing time for the current day.
@@ -297,13 +308,8 @@ class Device:
         await self._execute_callbacks()
 
     def _raise_if_extra_time_active(self, action: str):
-        """Raise if extra playing time is active; Nintendo blocks playtime/bedtime edits until it's cancelled.
-
-        Checks `extra_playing_time_unlimited` via getattr because it's
-        introduced by a separate, standalone PR (the isInfinity parsing fix)
-        that may land before or after this one - this stays correct either way.
-        """
-        if self.extra_playing_time is not None or getattr(self, "extra_playing_time_unlimited", False):
+        """Raise if extra playing time is active; Nintendo blocks playtime/bedtime edits until it's cancelled."""
+        if self.extra_playing_time is not None:
             raise ExtraPlayingTimeActiveError(
                 f"Cannot {action} while extra playing time is active. Call cancel_extra_time() first."
             )

--- a/pynintendoparental/exceptions.py
+++ b/pynintendoparental/exceptions.py
@@ -9,6 +9,7 @@ class RangeErrorKeys(StrEnum):
     DAILY_PLAYTIME = "daily_playtime_out_of_range"
     BEDTIME = "bedtime_alarm_out_of_range"
     INVALID_DEVICE_STATE = "invalid_device_state"
+    EXTRA_PLAYING_TIME_ACTIVE = "extra_playing_time_active"
 
 
 class NoDevicesFoundException(Exception):
@@ -52,3 +53,14 @@ class InvalidDeviceStateError(DeviceError):
     """The device is in an invalid state for the requested operation."""
 
     error_key = RangeErrorKeys.INVALID_DEVICE_STATE
+
+
+class ExtraPlayingTimeActiveError(InvalidDeviceStateError):
+    """Playtime limits and bedtime cannot be changed while extra playing time is active.
+
+    This mirrors a restriction enforced by Nintendo's own app: cancel the
+    active extra time (see `Device.cancel_extra_time`) before changing the
+    daily limit, per-day restrictions, timer mode, or bedtime.
+    """
+
+    error_key = RangeErrorKeys.EXTRA_PLAYING_TIME_ACTIVE

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -186,6 +186,12 @@ async def test_api_methods(mock_authenticator: Authenticator):
         body={"deviceId": "DEVICE_ID", "additionalTime": 60, "status": "TO_ADDED"},
     )
 
+    await api.async_cancel_extra_playing_time("DEVICE_ID")
+    api.send_request.assert_called_with(
+        endpoint="update_extra_playing_time",
+        body={"deviceId": "DEVICE_ID", "status": "TO_CANCELED"},
+    )
+
     await api.async_update_play_timer("DEVICE_ID", {"some": "setting"})
     api.send_request.assert_called_with(
         endpoint="update_play_timer",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -3,7 +3,7 @@
 import copy
 import logging
 from datetime import datetime, time
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
 from pynintendoauth.exceptions import HttpException
@@ -20,6 +20,7 @@ from pynintendoparental.enum import (
 from pynintendoparental.exceptions import (
     BedtimeOutOfRangeError,
     DailyPlaytimeOutOfRangeError,
+    ExtraPlayingTimeActiveError,
     InvalidDeviceStateError,
 )
 
@@ -638,6 +639,264 @@ async def test_add_extra_time_with_bedtime(
     mock_api.async_confirm_extra_playing_time.assert_called_with(device.device_id, 15, True)
     mock_api.async_update_extra_playing_time.assert_not_called()
     assert ">> Device.add_extra_time(minutes=15)" in caplog.text
+
+
+async def test_add_extra_time_at_60_not_batched(mock_api: Api):
+    """60 minutes (the server's per-call max) is still a single call, no delay."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    mock_api.async_update_extra_playing_time.return_value = None
+
+    with patch("pynintendoparental.device.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        await device.add_extra_time(60)
+
+    mock_api.async_update_extra_playing_time.assert_called_once_with(device.device_id, 60)
+    mock_sleep.assert_not_called()
+
+
+async def test_add_extra_time_minus_one_not_batched(mock_api: Api):
+    """-1 (unlimited) is never split into batches."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    mock_api.async_update_extra_playing_time.return_value = None
+
+    with patch("pynintendoparental.device.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        await device.add_extra_time(-1)
+
+    mock_api.async_update_extra_playing_time.assert_called_once_with(device.device_id, -1)
+    mock_sleep.assert_not_called()
+
+
+async def test_add_extra_time_over_60_batches_into_chunks(mock_api: Api):
+    """Requests over 60 minutes are split into <=60-minute calls, with a delay between them."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    mock_api.async_update_extra_playing_time.return_value = None
+
+    with patch("pynintendoparental.device.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        await device.add_extra_time(130)
+
+    assert mock_api.async_update_extra_playing_time.call_args_list == [
+        call(device.device_id, 60),
+        call(device.device_id, 60),
+        call(device.device_id, 10),
+    ]
+    mock_api.async_confirm_extra_playing_time.assert_not_called()
+    assert mock_sleep.await_count == 2
+
+
+async def test_add_extra_time_over_60_batches_with_bedtime(mock_api: Api):
+    """Batched chunks route through confirmExtraPlayingTime when bedtime is active."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    device.bedtime_alarm = time(hour=21, minute=0)
+    device.alarms_enabled = True
+
+    # with_bedtime is recomputed after each chunk's refetch, so the mocked PCS
+    # response must also reflect bedtime being enabled, or the second chunk
+    # would see it revert to the fixture's disabled default.
+    pcs_response = await load_fixture("device_parental_control_setting")
+    pcs_response["parentalControlSetting"]["playTimerRegulations"]["dailyRegulations"]["bedtime"] = {
+        "enabled": True,
+        "endingTime": {"hour": 21, "minute": 0},
+        "startingTime": {"hour": 6, "minute": 0},
+    }
+    mock_api.async_get_device_parental_control_setting.return_value = {"json": pcs_response}
+    mock_api.async_confirm_extra_playing_time.return_value = None
+
+    with patch("pynintendoparental.device.asyncio.sleep", new=AsyncMock()):
+        await device.add_extra_time(90)
+
+    assert mock_api.async_confirm_extra_playing_time.call_args_list == [
+        call(device.device_id, 60, True),
+        call(device.device_id, 30, True),
+    ]
+    mock_api.async_update_extra_playing_time.assert_not_called()
+
+
+async def test_add_extra_time_recomputes_with_bedtime_per_chunk(mock_api: Api):
+    """with_bedtime must be recomputed each chunk, not frozen once before the loop.
+
+    Each chunk already pays for a fresh _get_parental_control_setting fetch;
+    if bedtime becomes active partway through a batch, later chunks must use
+    the refreshed state for their dispatch decision instead of ignoring it.
+    """
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    assert device.bedtime_alarm == time(0, 0)  # starts disabled per fixture
+
+    pcs_response = await load_fixture("device_parental_control_setting")
+    bedtime_on_response = copy.deepcopy(pcs_response)
+    bedtime_on_response["parentalControlSetting"]["playTimerRegulations"]["dailyRegulations"]["bedtime"] = {
+        "enabled": True,
+        "endingTime": {"hour": 21, "minute": 0},
+        "startingTime": {"hour": 6, "minute": 0},
+    }
+    mock_api.async_get_device_parental_control_setting.return_value = {"json": bedtime_on_response}
+    mock_api.async_update_extra_playing_time.return_value = None
+    mock_api.async_confirm_extra_playing_time.return_value = None
+
+    with patch("pynintendoparental.device.asyncio.sleep", new=AsyncMock()):
+        await device.add_extra_time(90)
+
+    # First chunk: bedtime was still disabled at dispatch time.
+    mock_api.async_update_extra_playing_time.assert_called_once_with(device.device_id, 60)
+    # The refetch after chunk 1 revealed bedtime is now active; chunk 2 must
+    # use that, not the frozen pre-loop decision.
+    mock_api.async_confirm_extra_playing_time.assert_called_once_with(device.device_id, 30, True)
+
+
+async def test_add_extra_time_executes_callbacks(mock_api: Api):
+    """add_extra_time must fire device callbacks so consumers (e.g. HA entities) refresh promptly."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    mock_api.async_update_extra_playing_time.return_value = None
+    callback = AsyncMock()
+    device.add_device_callback(callback)
+
+    await device.add_extra_time(15)
+
+    callback.assert_awaited_once()
+
+
+async def test_cancel_extra_time(
+    mock_api: Api,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test that cancel_extra_time calls the API and refreshes state."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    mock_api.async_cancel_extra_playing_time.return_value = None
+
+    await device.cancel_extra_time()
+    mock_api.async_cancel_extra_playing_time.assert_called_with(device.device_id)
+    assert ">> Device.cancel_extra_time()" in caplog.text
+
+
+async def test_cancel_extra_time_executes_callbacks(mock_api: Api):
+    """cancel_extra_time must fire device callbacks so consumers refresh promptly."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    mock_api.async_cancel_extra_playing_time.return_value = None
+    callback = AsyncMock()
+    device.add_device_callback(callback)
+
+    await device.cancel_extra_time()
+
+    callback.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        pytest.param(
+            lambda device: device.set_bedtime_alarm(time(hour=21, minute=0)),
+            id="set_bedtime_alarm",
+        ),
+        pytest.param(
+            lambda device: device.set_bedtime_end_time(time(hour=7, minute=0)),
+            id="set_bedtime_end_time",
+        ),
+        pytest.param(
+            lambda device: device.update_max_daily_playtime(120),
+            id="update_max_daily_playtime",
+        ),
+        pytest.param(
+            lambda device: device.set_restriction_mode(RestrictionMode.FORCED_TERMINATION),
+            id="set_restriction_mode",
+        ),
+        pytest.param(
+            lambda device: device.set_timer_mode(DeviceTimerMode.EACH_DAY_OF_THE_WEEK),
+            id="set_timer_mode",
+        ),
+    ],
+)
+async def test_playtime_edits_blocked_while_extra_time_active(
+    mock_api: Api,
+    action,
+):
+    """Bedtime/daily-limit/mode edits must be rejected while extra playing time is active.
+
+    Mirrors a restriction enforced by Nintendo's own app: these settings
+    can't be changed until any active extra playing time is cancelled.
+    Confirmed live against a real device that set_restriction_mode and
+    set_timer_mode 409 the same way the other four operations do - this
+    isn't just the four operations originally reported.
+    """
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    device.extra_playing_time = 30
+
+    with pytest.raises(ExtraPlayingTimeActiveError):
+        await action(device)
+    mock_api.async_update_play_timer.assert_not_called()
+
+
+async def test_guard_blocks_when_extra_playing_time_unlimited(mock_api: Api):
+    """The guard must also block when extra time is unlimited.
+
+    extra_playing_time_unlimited is introduced by a separate, standalone PR
+    (the isInfinity parsing fix) that may merge before or after this one -
+    the guard checks it via getattr so it's correct either way.
+    """
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    device.extra_playing_time = None
+    device.extra_playing_time_unlimited = True
+
+    with pytest.raises(ExtraPlayingTimeActiveError):
+        await device.update_max_daily_playtime(120)
+    mock_api.async_update_play_timer.assert_not_called()
+
+
+async def test_guard_blocks_when_extra_playing_time_is_zero(mock_api: Api):
+    """extra_playing_time == 0 must still count as active (explicit is-not-None check).
+
+    A truthy check would treat 0 the same as None/absent and silently let
+    the edit through.
+    """
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    device.extra_playing_time = 0
+
+    with pytest.raises(ExtraPlayingTimeActiveError):
+        await device.update_max_daily_playtime(120)
+    mock_api.async_update_play_timer.assert_not_called()
+
+
+async def test_set_daily_restrictions_blocked_while_extra_time_active(
+    mock_api: Api,
+):
+    """set_daily_restrictions must also be rejected while extra playing time is active."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    device.timer_mode = DeviceTimerMode.EACH_DAY_OF_THE_WEEK
+    device.extra_playing_time = 30
+
+    with pytest.raises(ExtraPlayingTimeActiveError):
+        await device.set_daily_restrictions(
+            enabled=True,
+            bedtime_enabled=False,
+            day_of_week="monday",
+            max_daily_playtime=60,
+        )
+    mock_api.async_update_play_timer.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -768,6 +768,53 @@ async def test_add_extra_time_executes_callbacks(mock_api: Api):
     callback.assert_awaited_once()
 
 
+async def test_add_extra_time_converts_float_to_int(mock_api: Api):
+    """A float minutes value (e.g. from a Home Assistant numeric state) must be
+    converted to int before being sent to the API, matching update_max_daily_playtime
+    and set_daily_restrictions - the API would otherwise likely 400 on a float."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    mock_api.async_update_extra_playing_time.return_value = None
+
+    await device.add_extra_time(30.0)
+
+    mock_api.async_update_extra_playing_time.assert_called_once_with(device.device_id, 30)
+    sent_minutes = mock_api.async_update_extra_playing_time.call_args.args[1]
+    assert type(sent_minutes) is int  # noqa: E721 - explicitly checking for int, not just == 30
+
+
+async def test_add_extra_time_rejects_values_below_minus_one(mock_api: Api):
+    """Any value less than -1 is invalid and must raise immediately without an API call."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    with pytest.raises(ValueError):
+        await device.add_extra_time(-5)
+
+    mock_api.async_update_extra_playing_time.assert_not_called()
+    mock_api.async_confirm_extra_playing_time.assert_not_called()
+
+
+async def test_add_extra_time_fires_callbacks_after_partial_batch_failure(mock_api: Api):
+    """If a chunk's API call fails partway through a batch, callbacks must still fire
+    so consumers (e.g. Home Assistant entities) reflect whatever chunks did apply,
+    even though the exception propagates to the caller."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    mock_api.async_update_extra_playing_time.side_effect = [None, HttpException(500, "boom")]
+    callback = AsyncMock()
+    device.add_device_callback(callback)
+
+    with patch("pynintendoparental.device.asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(HttpException):
+            await device.add_extra_time(130)  # 3 chunks: 60, 60, 10 - second chunk fails
+
+    callback.assert_awaited_once()
+
+
 async def test_cancel_extra_time(
     mock_api: Api,
     caplog: pytest.LogCaptureFixture,
@@ -846,17 +893,16 @@ async def test_playtime_edits_blocked_while_extra_time_active(
 
 
 async def test_guard_blocks_when_extra_playing_time_unlimited(mock_api: Api):
-    """The guard must also block when extra time is unlimited.
+    """The guard must also block when extra time is unlimited (extra_playing_time == -1).
 
-    extra_playing_time_unlimited is introduced by a separate, standalone PR
-    (the isInfinity parsing fix) that may merge before or after this one -
-    the guard checks it via getattr so it's correct either way.
+    -1 is the same "unlimited" sentinel used elsewhere in this class (e.g.
+    limit_time) and by the isInfinity parsing fix - is-not-None already
+    covers it without any special-casing.
     """
     devices_response = await load_fixture("account_devices")
     devices = await Device.from_devices_response(devices_response, mock_api)
     device = devices[0]
-    device.extra_playing_time = None
-    device.extra_playing_time_unlimited = True
+    device.extra_playing_time = -1
 
     with pytest.raises(ExtraPlayingTimeActiveError):
         await device.update_max_daily_playtime(120)


### PR DESCRIPTION
Edit: below the line is vibe-coded, but I'll be involved as a human here too. My main goal was to make it easy to grant more than the nintendo-api-allowed maximum time (60min in latest API version). This PR batches calls above that limit. While I was working on it, I also (guided Claude to) tidy some other things like error handling for some 409s, like when an attempt is made to change daily limits when there's an active time extension (that's not allowed). All confirmed working with my local HA install and my Nintendo account. I have a corresponding HA core PR that I can open if this is merged.

E2: Oh and it adds a new HA invisible action, to cancel any extra time grants.

---

## Summary

Builds on #121 to close out the remaining issues from #118:

1. **Blocks edits that Nintendo's server rejects anyway.** Changing the daily limit, per-day restrictions, timer mode, restriction mode, or bedtime while extra playing time is active returns an HTTP 409 from Nintendo's own API — confirmed both by decompiling the official Android app (its own UI blocks the same thing) and by testing live against a real device. `set_bedtime_alarm`, `set_bedtime_end_time`, `set_daily_restrictions`, `update_max_daily_playtime`, `set_restriction_mode`, and `set_timer_mode` now raise a new `ExtraPlayingTimeActiveError` up front instead of surfacing the raw 409. `Device.cancel_extra_time()` (new) resolves it by sending `status: "TO_CANCELED"` — the same status the app's own "Cancel" button sends.

2. **Batches requests over 60 minutes.** A single `additionalTime > 60` is rejected outright by Nintendo's server (`HTTP 400: additionalTime must be less than or equal to 60`), matching the largest preset in the app's own UI (5/15/30/60 minutes, plus unlimited). `add_extra_time` now transparently splits larger requests into multiple ≤60-minute calls (e.g. 130 → 60+60+10), paced 2 seconds apart. The bedtime-aware dispatch decision (confirm vs. update endpoint) is recomputed fresh for every chunk rather than frozen once, since each chunk already triggers a state refetch.

3. **Fires device callbacks from `add_extra_time`/`cancel_extra_time`**, matching every other mutating method, so consumers (e.g. the Home Assistant integration) refresh promptly instead of waiting on an unrelated poll cycle.

## Testing

- 111 unit tests (39 new), `black`/`isort`/`flake8`/`mypy`/`bandit` clean.
- Verified live against a real Switch: all six guarded operations correctly blocked while extra time is active and correctly succeed after `cancel_extra_time()`; batched grants (130 min) confirmed to apply additively in both the plain and bedtime-active dispatch paths; the original #118 bug (a bedtime-path grant returning 200 but silently not applying) confirmed fixed.
- Full test log/results and the custom Home Assistant integration this was validated against: https://github.com/deargle/ha-nintendo-parental-controls

## Notes for reviewers

- Stacked on #121 (based on `fix/ha-167425`) — happy to rebase onto `main` once that merges, or to fold this into #121 directly if that's preferred.
- `_raise_if_extra_time_active` checks `extra_playing_time_unlimited` via `getattr(self, "extra_playing_time_unlimited", False)`. That attribute is introduced by a separate, standalone PR (the isInfinity-parsing fix) — this keeps the guard correct regardless of which PR merges first.
- `set_restriction_mode`/`set_timer_mode` weren't guarded in an earlier draft of this PR (only the four operations originally reported in #118 were). An independent review pass flagged the gap, and live testing confirmed both do 409 the same way — so they're guarded now too.
