### PR TITLE
Parse isInfinity so today_time_remaining doesn't understate unlimited extra time

### DIFF
--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -38,6 +38,9 @@ class Device:
         limit_time: Daily playtime limit in minutes (-1 if no limit).
         today_playing_time: Total playing time for the current day in minutes.
         today_time_remaining: Remaining playtime for the current day in minutes.
+        extra_playing_time_unlimited: True if granted extra time is unlimited
+            (TO_INFINITY) for the rest of the day; today_time_remaining
+            already accounts for this, it does not need separate handling.
         players: Dictionary of Player objects keyed by player ID.
         applications: Dictionary of Application objects keyed by application ID.
         timer_mode: Current timer mode (DAILY or EACH_DAY_OF_THE_WEEK).
@@ -60,6 +63,7 @@ class Device:
         self.players: dict[str, Player] = {}
         self.limit_time: int | float | None = 0
         self.extra_playing_time: int | None = None
+        self.extra_playing_time_unlimited: bool = False
         self.timer_mode: DeviceTimerMode | None = None
         self.today_playing_time: int | float = 0
         self.today_time_remaining: int | float = 0
@@ -633,6 +637,7 @@ class Device:
         # Parse extra playing time based on whether bedtime is enabled
         extra_playing_time_data = pcs.get("ownedDevice", {}).get("device", {}).get("extraPlayingTime")
         self.extra_playing_time = None
+        self.extra_playing_time_unlimited = False
         if extra_playing_time_data is not None:
             if bedtime_enabled and extra_playing_time_data.get("bedtime"):
                 # When bedtime is enabled, calculate the difference between new bedtime and original bedtime
@@ -652,7 +657,10 @@ class Device:
                 # When bedtime is disabled, use inOneDay duration
                 in_one_day = extra_playing_time_data.get("inOneDay")
                 if in_one_day is not None:
-                    self.extra_playing_time = in_one_day.get("duration")
+                    if in_one_day.get("isInfinity"):
+                        self.extra_playing_time_unlimited = True
+                    else:
+                        self.extra_playing_time = in_one_day.get("duration")
         if bedtime_setting.get("enabled") and bedtime_setting["startingTime"]:
             self.bedtime_end = time(
                 hour=bedtime_setting["startingTime"]["hour"],
@@ -699,8 +707,9 @@ class Device:
             minutes_in_day = 1440  # 24 * 60
             current_minutes_past_midnight = now.hour * 60 + now.minute
 
-            if self.limit_time in (-1, None):
-                # No play limit, so remaining time is until end of day.
+            if self.limit_time in (-1, None) or self.extra_playing_time_unlimited:
+                # No play limit (or unlimited extra time granted), so remaining
+                # time is until end of day.
                 time_remaining_by_play_limit = minutes_in_day - current_minutes_past_midnight
             else:
                 # Calculate remaining time from play limit, adding any extra playing time

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -38,9 +38,8 @@ class Device:
         limit_time: Daily playtime limit in minutes (-1 if no limit).
         today_playing_time: Total playing time for the current day in minutes.
         today_time_remaining: Remaining playtime for the current day in minutes.
-        extra_playing_time_unlimited: True if granted extra time is unlimited
-            (TO_INFINITY) for the rest of the day; today_time_remaining
-            already accounts for this, it does not need separate handling.
+        extra_playing_time: Extra/bonus playing time granted for today, in
+            minutes, or -1 if unlimited (TO_INFINITY) for the rest of the day.
         players: Dictionary of Player objects keyed by player ID.
         applications: Dictionary of Application objects keyed by application ID.
         timer_mode: Current timer mode (DAILY or EACH_DAY_OF_THE_WEEK).
@@ -63,7 +62,6 @@ class Device:
         self.players: dict[str, Player] = {}
         self.limit_time: int | float | None = 0
         self.extra_playing_time: int | None = None
-        self.extra_playing_time_unlimited: bool = False
         self.timer_mode: DeviceTimerMode | None = None
         self.today_playing_time: int | float = 0
         self.today_time_remaining: int | float = 0
@@ -637,7 +635,6 @@ class Device:
         # Parse extra playing time based on whether bedtime is enabled
         extra_playing_time_data = pcs.get("ownedDevice", {}).get("device", {}).get("extraPlayingTime")
         self.extra_playing_time = None
-        self.extra_playing_time_unlimited = False
         if extra_playing_time_data is not None:
             if bedtime_enabled and extra_playing_time_data.get("bedtime"):
                 # When bedtime is enabled, calculate the difference between new bedtime and original bedtime
@@ -654,11 +651,13 @@ class Device:
                     # Update bedtime_alarm to the extended bedtime
                     self.bedtime_alarm = extended_bedtime
             else:
-                # When bedtime is disabled, use inOneDay duration
+                # When bedtime is disabled, use inOneDay duration. -1 (matching
+                # the same "unlimited" sentinel limit_time and the API already
+                # use) represents Nintendo's isInfinity/TO_INFINITY grant.
                 in_one_day = extra_playing_time_data.get("inOneDay")
                 if in_one_day is not None:
                     if in_one_day.get("isInfinity"):
-                        self.extra_playing_time_unlimited = True
+                        self.extra_playing_time = -1
                     else:
                         self.extra_playing_time = in_one_day.get("duration")
         if bedtime_setting.get("enabled") and bedtime_setting["startingTime"]:
@@ -707,7 +706,7 @@ class Device:
             minutes_in_day = 1440  # 24 * 60
             current_minutes_past_midnight = now.hour * 60 + now.minute
 
-            if self.limit_time in (-1, None) or self.extra_playing_time_unlimited:
+            if self.limit_time in (-1, None) or self.extra_playing_time == -1:
                 # No play limit (or unlimited extra time granted), so remaining
                 # time is until end of day.
                 time_remaining_by_play_limit = minutes_in_day - current_minutes_past_midnight

--- a/tests/snapshots/test_device.ambr
+++ b/tests/snapshots/test_device.ambr
@@ -1357,7 +1357,6 @@
       'updatedAt': 1764668290,
     }),
     'extra_playing_time': None,
-    'extra_playing_time_unlimited': False,
     'forced_termination_mode': False,
     'last_month_playing_time': 0,
     'last_month_summary': dict({

--- a/tests/snapshots/test_device.ambr
+++ b/tests/snapshots/test_device.ambr
@@ -1357,6 +1357,7 @@
       'updatedAt': 1764668290,
     }),
     'extra_playing_time': None,
+    'extra_playing_time_unlimited': False,
     'forced_termination_mode': False,
     'last_month_playing_time': 0,
     'last_month_summary': dict({

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -750,16 +750,16 @@ async def test_parse_with_extra_playing_time(mock_api: Api):
     await device.update()
 
     assert device.extra_playing_time == 50
-    assert device.extra_playing_time_unlimited is False
 
 
 async def test_parse_with_extra_playing_time_infinity(mock_api: Api):
-    """Test that isInfinity is parsed into extra_playing_time_unlimited, not a numeric duration."""
+    """Test that isInfinity is parsed into extra_playing_time as -1 (the same "unlimited" sentinel
+    already used by limit_time and the update_extra_playing_time API method), not a separate flag."""
     devices_response = await load_fixture("account_devices")
     devices = await Device.from_devices_response(devices_response, mock_api)
     device = devices[0]
 
-    assert device.extra_playing_time_unlimited is False
+    assert device.extra_playing_time is None
 
     pcs_response = await load_fixture("device_parental_control_setting")
     pcs_response["ownedDevice"]["device"]["extraPlayingTime"] = {
@@ -769,8 +769,7 @@ async def test_parse_with_extra_playing_time_infinity(mock_api: Api):
     mock_api.async_get_device_parental_control_setting.return_value = {"json": pcs_response}
     await device.update()
 
-    assert device.extra_playing_time_unlimited is True
-    assert device.extra_playing_time is None
+    assert device.extra_playing_time == -1
 
 
 async def test_parse_with_extra_playing_time_bedtime_enabled(mock_api: Api):
@@ -912,7 +911,7 @@ async def test_today_time_remaining_with_infinite_extra_playing_time(mock_api: A
 
     await device.update()
 
-    assert device.extra_playing_time_unlimited is True
+    assert device.extra_playing_time == -1
     assert device.limit_time == 60
     assert device.today_playing_time == 20
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -750,6 +750,27 @@ async def test_parse_with_extra_playing_time(mock_api: Api):
     await device.update()
 
     assert device.extra_playing_time == 50
+    assert device.extra_playing_time_unlimited is False
+
+
+async def test_parse_with_extra_playing_time_infinity(mock_api: Api):
+    """Test that isInfinity is parsed into extra_playing_time_unlimited, not a numeric duration."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    assert device.extra_playing_time_unlimited is False
+
+    pcs_response = await load_fixture("device_parental_control_setting")
+    pcs_response["ownedDevice"]["device"]["extraPlayingTime"] = {
+        "inOneDay": {"duration": None, "isInfinity": True},
+    }
+
+    mock_api.async_get_device_parental_control_setting.return_value = {"json": pcs_response}
+    await device.update()
+
+    assert device.extra_playing_time_unlimited is True
+    assert device.extra_playing_time is None
 
 
 async def test_parse_with_extra_playing_time_bedtime_enabled(mock_api: Api):
@@ -848,6 +869,59 @@ async def test_today_time_remaining_with_extra_playing_time(mock_api: Api):
     remaining_by_end_of_day = minutes_in_day - current_minutes_past_midnight
     remaining_by_play_limit = 70
     expected_remaining = min(remaining_by_play_limit, remaining_by_end_of_day)
+
+    assert device.today_time_remaining == expected_remaining
+
+
+async def test_today_time_remaining_with_infinite_extra_playing_time(mock_api: Api):
+    """today_time_remaining must not be capped by the daily limit when extra time is unlimited.
+
+    Previously isInfinity wasn't parsed at all, so an unlimited grant fell back
+    to a falsy extra_playing_time and today_time_remaining showed just the
+    (much smaller) finite daily limit instead of reading as unlimited.
+    """
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    pcs_response = await load_fixture("device_parental_control_setting")
+
+    # A small daily play limit of 60 minutes - unlimited extra time should
+    # override this entirely, not just add a finite bonus on top.
+    pcs_response["parentalControlSetting"]["playTimerRegulations"]["dailyRegulations"]["timeToPlayInOneDay"] = {
+        "enabled": True,
+        "limitTime": 60,
+    }
+    pcs_response["parentalControlSetting"]["playTimerRegulations"]["dailyRegulations"]["bedtime"] = {
+        "enabled": False,
+        "endingTime": None,
+        "startingTime": {"hour": 6, "minute": 0},
+    }
+    pcs_response["ownedDevice"]["device"]["extraPlayingTime"] = {
+        "inOneDay": {"duration": None, "isInfinity": True},
+        "bedtime": None,
+        "expiresAt": 1770335999,
+    }
+    mock_api.async_get_device_parental_control_setting.return_value = {"json": pcs_response}
+
+    daily_summaries_response = await load_fixture("device_daily_summaries")
+    today = datetime.now().strftime("%Y-%m-%d")
+    daily_summaries_response["dailySummaries"][0]["date"] = today
+    daily_summaries_response["dailySummaries"][0]["playingTime"] = 20
+    mock_api.async_get_device_daily_summaries.return_value = {"json": daily_summaries_response}
+
+    await device.update()
+
+    assert device.extra_playing_time_unlimited is True
+    assert device.limit_time == 60
+    assert device.today_playing_time == 20
+
+    # Same "remaining until end of day" this library already uses for
+    # limit_time in (-1, None) - not (60 - 20) and definitely not negative.
+    now = datetime.now()
+    minutes_in_day = 1440
+    current_minutes_past_midnight = now.hour * 60 + now.minute
+    expected_remaining = minutes_in_day - current_minutes_past_midnight
 
     assert device.today_time_remaining == expected_remaining
 


### PR DESCRIPTION
Below the line is Claude. My goal was as stated in the title here.

---

## Summary

The real API response for `extraPlayingTime.inOneDay` includes an `isInfinity` flag alongside `duration` (visible in this repo's own test fixtures: `{"duration": 30, "isInfinity": false}`), but `Device._parse_parental_control_setting` only ever read `duration`. When Nintendo grants unlimited extra time (`TO_INFINITY`), `duration` comes back null, so `extra_playing_time` silently fell back to `None` and `today_time_remaining` displayed just the finite daily limit instead of reading as unlimited.

Adds `Device.extra_playing_time_unlimited: bool`, parsed from `isInfinity`, and has `_calculate_today_remaining_time` treat it the same way `limit_time in (-1, None)` is already treated — remaining time computed as "until end of day," not derived from the finite limit.

## Testing

- 2 new unit tests, 92 total passing, coverage 93%, `black`/`isort`/`bandit` clean.
- Verified live: with a 15-minute daily limit set, requesting unlimited (`-1`) extra time now reads `today_time_remaining` as 82 (minutes until local midnight at test time) instead of 15.
- Custom Home Assistant integration this was validated against: https://github.com/deargle/ha-nintendo-parental-controls

## Notes for reviewers

- Standalone, based on `main` — independent of #121 and of the cancel/batching PR, so it can merge in any order relative to those.
- ~Introduces a separate `extra_playing_time_unlimited` bool rather than reusing the existing "`-1` means unlimited" convention already used for `limit_time`. Happy to switch to reusing `-1` for `extra_playing_time` on read instead, if that's preferred for consistency with the rest of the class — flagging this as a judgment call rather than picking unilaterally.~ 
 
---

Gemini wanted the sentinel, but I (deargle) still don't like it.
