### PR TITLE
Add cancel_extra_time and guard playtime/bedtime/mode edits while active

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ All methods are asynchronous.
 - `remove_device_callback(callback)`: Removes a previously added callback.
 - `set_new_pin(pin: str)`: Sets a new PIN for the parental controls.
 - `add_extra_time(minutes: int)`: Adds extra playing time for the current day.
+- `cancel_extra_time()`: Cancels any active extra playing time for the current day. Required before changing
+  the daily limit, per-day restrictions, timer mode, restriction mode, or bedtime while extra time is active.
 - `update_max_daily_playtime(minutes: int)`: Sets the daily playtime limit. Use `-1` to remove the limit.
 - `set_restriction_mode(mode: RestrictionMode)`: Sets the restriction mode.
     - `RestrictionMode.FORCED_TERMINATION`: The software will be suspended when the playtime limit is reached.

--- a/pynintendoparental/api.py
+++ b/pynintendoparental/api.py
@@ -181,3 +181,8 @@ class Api:
             body["status"] = "TO_INFINITY"
             body.pop("additionalTime")
         return await self.send_request(endpoint="update_extra_playing_time", body=body)
+
+    async def async_cancel_extra_playing_time(self, device_id: str) -> dict:
+        """Cancel any active extra playing time for the current day."""
+        body = {"deviceId": device_id, "status": "TO_CANCELED"}
+        return await self.send_request(endpoint="update_extra_playing_time", body=body)

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -19,6 +19,7 @@ from .enum import (
 from .exceptions import (
     BedtimeOutOfRangeError,
     DailyPlaytimeOutOfRangeError,
+    ExtraPlayingTimeActiveError,
     InvalidDeviceStateError,
 )
 from .player import Player
@@ -228,6 +229,30 @@ class Device:
         await self._api.async_update_extra_playing_time(self.device_id, minutes)
         await self._get_parental_control_setting(datetime.now())
 
+    async def cancel_extra_time(self):
+        """Cancel any active extra playing time for the current day.
+
+        Nintendo's own app requires this before the daily limit, per-day
+        restrictions, timer mode, or bedtime can be changed while extra time
+        is active (see `Device.update_max_daily_playtime` and friends).
+
+        Example:
+            ```python
+            await device.cancel_extra_time()
+            ```
+        """
+        _LOGGER.debug(">> Device.cancel_extra_time()")
+        await self._api.async_cancel_extra_playing_time(self.device_id)
+        await self._get_parental_control_setting(datetime.now())
+        await self._execute_callbacks()
+
+    def _raise_if_extra_time_active(self, action: str):
+        """Raise if extra playing time is active; Nintendo blocks playtime/bedtime edits until it's cancelled."""
+        if self.extra_playing_time is not None:
+            raise ExtraPlayingTimeActiveError(
+                f"Cannot {action} while extra playing time is active. Call cancel_extra_time() first."
+            )
+
     async def set_restriction_mode(self, mode: RestrictionMode):
         """Set the restriction mode for playtime limits.
 
@@ -242,8 +267,12 @@ class Device:
 
             await device.set_restriction_mode(RestrictionMode.FORCED_TERMINATION)
             ```
+
+        Raises:
+            ExtraPlayingTimeActiveError: If extra playing time is currently active.
         """
         _LOGGER.debug(">> Device.set_restriction_mode(mode=%s)", mode)
+        self._raise_if_extra_time_active("change the restriction mode")
         self.parental_control_settings["playTimerRegulations"]["restrictionMode"] = str(mode)
         response = await self._api.async_update_play_timer(
             self.device_id,
@@ -264,6 +293,7 @@ class Device:
 
         Raises:
             BedtimeOutOfRangeError: If the time is outside the valid range.
+            ExtraPlayingTimeActiveError: If extra playing time is currently active.
 
         Example:
             ```python
@@ -274,6 +304,7 @@ class Device:
             ```
         """
         _LOGGER.debug(">> Device.set_bedtime_alarm(value=%s)", value)
+        self._raise_if_extra_time_active("change the bedtime alarm")
         if not ((16 <= value.hour <= 23) or (value.hour == 0 and value.minute == 0)):
             raise BedtimeOutOfRangeError(value=value)
         now = datetime.now()
@@ -319,6 +350,7 @@ class Device:
 
         Raises:
             BedtimeOutOfRangeError: If the time is outside the valid range.
+            ExtraPlayingTimeActiveError: If extra playing time is currently active.
 
         Example:
             ```python
@@ -329,6 +361,7 @@ class Device:
             ```
         """
         _LOGGER.debug(">> Device.set_bedtime_end_time(value=%s)", value)
+        self._raise_if_extra_time_active("change the bedtime end time")
         if not time(5, 0) <= value <= time(9, 0) and value != time(0, 0):
             raise BedtimeOutOfRangeError(value=value)
         now = datetime.now()
@@ -372,8 +405,12 @@ class Device:
 
             await device.set_timer_mode(DeviceTimerMode.DAILY)
             ```
+
+        Raises:
+            ExtraPlayingTimeActiveError: If extra playing time is currently active.
         """
         _LOGGER.debug(">> Device.set_timer_mode(mode=%s)", mode)
+        self._raise_if_extra_time_active("change the timer mode")
         self.timer_mode = mode
         self.parental_control_settings["playTimerRegulations"]["timerMode"] = str(mode)
         await self._send_api_update(
@@ -407,6 +444,7 @@ class Device:
             InvalidDeviceStateError: If timer_mode is not EACH_DAY_OF_THE_WEEK.
             ValueError: If day_of_week is invalid.
             BedtimeOutOfRangeError: If bedtime values are outside valid ranges.
+            ExtraPlayingTimeActiveError: If extra playing time is currently active.
 
         Example:
             ```python
@@ -433,6 +471,7 @@ class Device:
             bedtime_end,
             max_daily_playtime,
         )
+        self._raise_if_extra_time_active("change daily restrictions")
         if self.timer_mode != DeviceTimerMode.EACH_DAY_OF_THE_WEEK:
             raise InvalidDeviceStateError("Daily restrictions can only be set when timer_mode is EACH_DAY_OF_THE_WEEK.")
         if day_of_week not in DAYS_OF_WEEK:
@@ -520,6 +559,7 @@ class Device:
 
         Raises:
             DailyPlaytimeOutOfRangeError: If minutes is outside the valid range.
+            ExtraPlayingTimeActiveError: If extra playing time is currently active.
 
         Example:
             ```python
@@ -528,6 +568,7 @@ class Device:
             ```
         """
         _LOGGER.debug(">> Device.update_max_daily_playtime(minutes=%s)", minutes)
+        self._raise_if_extra_time_active("change the daily playtime limit")
         if isinstance(minutes, float):
             minutes = int(minutes)
         if not (-1 <= minutes <= 360):

--- a/pynintendoparental/exceptions.py
+++ b/pynintendoparental/exceptions.py
@@ -9,6 +9,7 @@ class RangeErrorKeys(StrEnum):
     DAILY_PLAYTIME = "daily_playtime_out_of_range"
     BEDTIME = "bedtime_alarm_out_of_range"
     INVALID_DEVICE_STATE = "invalid_device_state"
+    EXTRA_PLAYING_TIME_ACTIVE = "extra_playing_time_active"
 
 
 class NoDevicesFoundException(Exception):
@@ -52,3 +53,14 @@ class InvalidDeviceStateError(DeviceError):
     """The device is in an invalid state for the requested operation."""
 
     error_key = RangeErrorKeys.INVALID_DEVICE_STATE
+
+
+class ExtraPlayingTimeActiveError(InvalidDeviceStateError):
+    """Playtime limits and bedtime cannot be changed while extra playing time is active.
+
+    This mirrors a restriction enforced by Nintendo's own app: cancel the
+    active extra time (see `Device.cancel_extra_time`) before changing the
+    daily limit, per-day restrictions, timer mode, or bedtime.
+    """
+
+    error_key = RangeErrorKeys.EXTRA_PLAYING_TIME_ACTIVE

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -174,6 +174,12 @@ async def test_api_methods(mock_authenticator: Authenticator):
         body={"deviceId": "DEVICE_ID", "additionalTime": 60, "status": "TO_ADDED"},
     )
 
+    await api.async_cancel_extra_playing_time("DEVICE_ID")
+    api.send_request.assert_called_with(
+        endpoint="update_extra_playing_time",
+        body={"deviceId": "DEVICE_ID", "status": "TO_CANCELED"},
+    )
+
     await api.async_update_play_timer("DEVICE_ID", {"some": "setting"})
     api.send_request.assert_called_with(
         endpoint="update_play_timer",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -20,6 +20,7 @@ from pynintendoparental.enum import (
 from pynintendoparental.exceptions import (
     BedtimeOutOfRangeError,
     DailyPlaytimeOutOfRangeError,
+    ExtraPlayingTimeActiveError,
     InvalidDeviceStateError,
 )
 
@@ -616,6 +617,136 @@ async def test_add_extra_time(
     await device.add_extra_time(extra_time)
     mock_api.async_update_extra_playing_time.assert_called_with(device.device_id, extra_time)
     assert f">> Device.add_extra_time(minutes={extra_time})" in caplog.text
+
+
+async def test_cancel_extra_time(
+    mock_api: Api,
+    caplog: pytest.LogCaptureFixture,
+):
+    """Test that cancel_extra_time calls the API and refreshes state."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    mock_api.async_cancel_extra_playing_time.return_value = None
+
+    await device.cancel_extra_time()
+    mock_api.async_cancel_extra_playing_time.assert_called_with(device.device_id)
+    assert ">> Device.cancel_extra_time()" in caplog.text
+
+
+async def test_cancel_extra_time_executes_callbacks(mock_api: Api):
+    """cancel_extra_time must fire device callbacks so consumers refresh promptly."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    mock_api.async_cancel_extra_playing_time.return_value = None
+    callback = AsyncMock()
+    device.add_device_callback(callback)
+
+    await device.cancel_extra_time()
+
+    callback.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "action",
+    [
+        pytest.param(
+            lambda device: device.set_bedtime_alarm(time(hour=21, minute=0)),
+            id="set_bedtime_alarm",
+        ),
+        pytest.param(
+            lambda device: device.set_bedtime_end_time(time(hour=7, minute=0)),
+            id="set_bedtime_end_time",
+        ),
+        pytest.param(
+            lambda device: device.update_max_daily_playtime(120),
+            id="update_max_daily_playtime",
+        ),
+        pytest.param(
+            lambda device: device.set_restriction_mode(RestrictionMode.FORCED_TERMINATION),
+            id="set_restriction_mode",
+        ),
+        pytest.param(
+            lambda device: device.set_timer_mode(DeviceTimerMode.EACH_DAY_OF_THE_WEEK),
+            id="set_timer_mode",
+        ),
+    ],
+)
+async def test_playtime_edits_blocked_while_extra_time_active(
+    mock_api: Api,
+    action,
+):
+    """Bedtime/daily-limit/mode edits must be rejected while extra playing time is active.
+
+    Mirrors a restriction enforced by Nintendo's own app: these settings
+    can't be changed until any active extra playing time is cancelled.
+    Confirmed live against a real device that set_restriction_mode and
+    set_timer_mode 409 the same way the other four operations do - this
+    isn't just the four operations originally reported.
+    """
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    device.extra_playing_time = 30
+
+    with pytest.raises(ExtraPlayingTimeActiveError):
+        await action(device)
+    mock_api.async_update_play_timer.assert_not_called()
+
+
+async def test_guard_blocks_when_extra_playing_time_unlimited(mock_api: Api):
+    """The guard must also block when extra time is unlimited (extra_playing_time == -1).
+
+    -1 is the same "unlimited" sentinel used elsewhere in this class (e.g.
+    limit_time) and by the isInfinity parsing fix - is-not-None already
+    covers it without any special-casing.
+    """
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    device.extra_playing_time = -1
+
+    with pytest.raises(ExtraPlayingTimeActiveError):
+        await device.update_max_daily_playtime(120)
+    mock_api.async_update_play_timer.assert_not_called()
+
+
+async def test_guard_blocks_when_extra_playing_time_is_zero(mock_api: Api):
+    """extra_playing_time == 0 must still count as active (explicit is-not-None check).
+
+    A truthy check would treat 0 the same as None/absent and silently let
+    the edit through.
+    """
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    device.extra_playing_time = 0
+
+    with pytest.raises(ExtraPlayingTimeActiveError):
+        await device.update_max_daily_playtime(120)
+    mock_api.async_update_play_timer.assert_not_called()
+
+
+async def test_set_daily_restrictions_blocked_while_extra_time_active(
+    mock_api: Api,
+):
+    """set_daily_restrictions must also be rejected while extra playing time is active."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    device.timer_mode = DeviceTimerMode.EACH_DAY_OF_THE_WEEK
+    device.extra_playing_time = 30
+
+    with pytest.raises(ExtraPlayingTimeActiveError):
+        await device.set_daily_restrictions(
+            enabled=True,
+            bedtime_enabled=False,
+            day_of_week="monday",
+            max_daily_playtime=60,
+        )
+    mock_api.async_update_play_timer.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I kept this one together because of how thematically interdependent they are. Can split further if if you have a strong preference.

Claude says:

---

## Summary

Split out from #129 at the maintainer's request, so each fix lands as its own independently reviewable/mergeable change. This PR is the "guard" half — it has no dependency on #121 and applies directly to `main`.

Blocks edits that Nintendo's server rejects anyway. Changing the daily limit, per-day restrictions, timer mode, restriction mode, or bedtime while extra playing time is active returns an HTTP 409 from Nintendo's own API — confirmed both by decompiling the official Android app (its own UI blocks the same thing) and by testing live against a real device. `set_bedtime_alarm`, `set_bedtime_end_time`, `set_daily_restrictions`, `update_max_daily_playtime`, `set_restriction_mode`, and `set_timer_mode` now raise a new `ExtraPlayingTimeActiveError` up front instead of surfacing the raw 409. `Device.cancel_extra_time()` (new) resolves it by sending `status: "TO_CANCELED"` — the same status the app's own "Cancel" button sends.

Also fires device callbacks from `cancel_extra_time()`, matching every other mutating method, so consumers (e.g. the Home Assistant integration) refresh promptly instead of waiting on an unrelated poll cycle.

## Testing

- 105 unit tests, `black`/`isort`/`flake8`/`bandit` clean (2 pre-existing formatting issues in files this PR doesn't touch are unaffected, confirmed identical on `main`).
- Verified live against a real Switch, standalone (this branch only, nothing from the batching PR present): granted bonus time via Home Assistant's `add_bonus_time` service, confirmed a subsequent settings change was correctly blocked with `ExtraPlayingTimeActiveError` (surfaced to the user as a clean `ServiceValidationError`), then confirmed `cancel_bonus_time` cleared it and the settings change succeeded normally afterward.
- Full test log/results and the custom Home Assistant integration this was validated against: https://github.com/deargle/ha-nintendo-parental-controls

## Notes for reviewers

- This was originally bundled with the >60-minute batching fix in #129. Per feedback that the two should ship as separate, independently reviewable PRs, they've been split — this one and #132 (batching, stacked on #121 since it extends logic introduced there).
- `set_restriction_mode`/`set_timer_mode` weren't guarded in an earlier draft (only the four operations originally reported in #118 were). Live testing confirmed both 409 the same way, so they're guarded now too.