### PR TITLE
Batch add_extra_time requests over 60 minutes into multiple calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ All methods are asynchronous.
 - `add_device_callback(callback)`: Adds a callback that will be called when the device state changes.
 - `remove_device_callback(callback)`: Removes a previously added callback.
 - `set_new_pin(pin: str)`: Sets a new PIN for the parental controls.
-- `add_extra_time(minutes: int)`: Adds extra playing time for the current day.
+- `add_extra_time(minutes: int)`: Adds extra playing time for the current day. Use `-1` to grant unlimited time for the rest of the day. Nintendo's server rejects more than 60 minutes in a single request, so amounts above that are transparently split into multiple <=60-minute calls, paced a couple of seconds apart.
 - `update_max_daily_playtime(minutes: int)`: Sets the daily playtime limit. Use `-1` to remove the limit.
 - `set_restriction_mode(mode: RestrictionMode)`: Sets the restriction mode.
     - `RestrictionMode.FORCED_TERMINATION`: The software will be suspended when the playtime limit is reached.

--- a/pynintendoparental/device.py
+++ b/pynintendoparental/device.py
@@ -24,6 +24,33 @@ from .exceptions import (
 from .player import Player
 from .utils import is_awaitable
 
+# Nintendo's server hard-rejects additionalTime > 60 on a single
+# updateExtraPlayingTime/confirmExtraPlayingTime call (HTTP 400:
+# "additionalTime must be less than or equal to 60"), matching the app's own
+# largest bonus-time preset (ONE_HOUR). Requests above this are split into
+# multiple calls.
+_MAX_EXTRA_TIME_MINUTES_PER_CALL = 60
+# Paced between batched calls rather than fired back-to-back, since the
+# server appears to need a moment to settle each write before the next one
+# (and to avoid hammering the API).
+_EXTRA_TIME_BATCH_DELAY_SECONDS = 2
+
+
+def _split_extra_time(minutes: int) -> list[int]:
+    """Split a requested extra-time amount into <=60-minute chunks.
+
+    -1 (unlimited/TO_INFINITY) is never split, regardless of size.
+    """
+    if minutes == -1 or minutes <= _MAX_EXTRA_TIME_MINUTES_PER_CALL:
+        return [minutes]
+    chunks = []
+    remaining = minutes
+    while remaining > 0:
+        chunk = min(remaining, _MAX_EXTRA_TIME_MINUTES_PER_CALL)
+        chunks.append(chunk)
+        remaining -= chunk
+    return chunks
+
 
 class Device:
     """A Nintendo Switch device.
@@ -217,25 +244,50 @@ class Device:
         This grants additional playing time beyond the configured daily limit
         for the current day only. The extra time does not carry over to other days.
 
+        Nintendo's server rejects more than 60 minutes in a single request, so
+        larger amounts are transparently split into multiple <=60-minute
+        calls, paced a couple of seconds apart. `-1` (unlimited) is always a
+        single call regardless of size. Each chunk re-evaluates whether
+        bedtime is active from freshly-fetched state, so a bedtime change
+        mid-batch is picked up for the remaining chunks. If a chunk's API
+        call raises partway through, earlier chunks remain applied - check
+        `extra_playing_time` afterward to see how much actually went through.
+
         Args:
-            minutes: Number of additional minutes to add (must be positive).
+            minutes: Number of additional minutes to add (must be positive), or
+                -1 to grant unlimited time for the rest of the day.
+
+        Raises:
+            ValueError: If minutes is less than -1.
 
         Example:
             ```python
-            await device.add_extra_time(30)  # Add 30 minutes
+            await device.add_extra_time(30)   # Add 30 minutes
+            await device.add_extra_time(130)  # Add 130 minutes, batched as 60+60+10
             ```
         """
         _LOGGER.debug(">> Device.add_extra_time(minutes=%s)", minutes)
-        with_bedtime = (
-            self.bedtime_alarm is not None
-            and self.bedtime_alarm != time(hour=0, minute=0)
-            and self.alarms_enabled
-        )
-        if minutes != -1 and with_bedtime:
-            await self._api.async_confirm_extra_playing_time(self.device_id, minutes, True)
-        else:
-            await self._api.async_update_extra_playing_time(self.device_id, minutes)
-        await self._get_parental_control_setting(datetime.now())
+        if isinstance(minutes, float):
+            minutes = int(minutes)
+        if minutes < -1:
+            raise ValueError("minutes must be -1 or a non-negative integer.")
+        chunks = _split_extra_time(minutes)
+        try:
+            for index, chunk in enumerate(chunks):
+                with_bedtime = (
+                    self.bedtime_alarm is not None
+                    and self.bedtime_alarm != time(hour=0, minute=0)
+                    and self.alarms_enabled
+                )
+                if chunk != -1 and with_bedtime:
+                    await self._api.async_confirm_extra_playing_time(self.device_id, chunk, True)
+                else:
+                    await self._api.async_update_extra_playing_time(self.device_id, chunk)
+                await self._get_parental_control_setting(datetime.now())
+                if index < len(chunks) - 1:
+                    await asyncio.sleep(_EXTRA_TIME_BATCH_DELAY_SECONDS)
+        finally:
+            await self._execute_callbacks()
 
     async def set_restriction_mode(self, mode: RestrictionMode):
         """Set the restriction mode for playtime limits.

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -3,7 +3,7 @@
 import copy
 import logging
 from datetime import datetime, time
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call, patch
 
 import pytest
 from pynintendoauth.exceptions import HttpException
@@ -638,6 +638,180 @@ async def test_add_extra_time_with_bedtime(
     mock_api.async_confirm_extra_playing_time.assert_called_with(device.device_id, 15, True)
     mock_api.async_update_extra_playing_time.assert_not_called()
     assert ">> Device.add_extra_time(minutes=15)" in caplog.text
+
+
+async def test_add_extra_time_at_60_not_batched(mock_api: Api):
+    """60 minutes (the server's per-call max) is still a single call, no delay."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    mock_api.async_update_extra_playing_time.return_value = None
+
+    with patch("pynintendoparental.device.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        await device.add_extra_time(60)
+
+    mock_api.async_update_extra_playing_time.assert_called_once_with(device.device_id, 60)
+    mock_sleep.assert_not_called()
+
+
+async def test_add_extra_time_minus_one_not_batched(mock_api: Api):
+    """-1 (unlimited) is never split into batches."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    mock_api.async_update_extra_playing_time.return_value = None
+
+    with patch("pynintendoparental.device.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        await device.add_extra_time(-1)
+
+    mock_api.async_update_extra_playing_time.assert_called_once_with(device.device_id, -1)
+    mock_sleep.assert_not_called()
+
+
+async def test_add_extra_time_over_60_batches_into_chunks(mock_api: Api):
+    """Requests over 60 minutes are split into <=60-minute calls, with a delay between them."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    mock_api.async_update_extra_playing_time.return_value = None
+
+    with patch("pynintendoparental.device.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        await device.add_extra_time(130)
+
+    assert mock_api.async_update_extra_playing_time.call_args_list == [
+        call(device.device_id, 60),
+        call(device.device_id, 60),
+        call(device.device_id, 10),
+    ]
+    mock_api.async_confirm_extra_playing_time.assert_not_called()
+    assert mock_sleep.await_count == 2
+
+
+async def test_add_extra_time_over_60_batches_with_bedtime(mock_api: Api):
+    """Batched chunks route through confirmExtraPlayingTime when bedtime is active."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    device.bedtime_alarm = time(hour=21, minute=0)
+    device.alarms_enabled = True
+
+    # with_bedtime is recomputed after each chunk's refetch, so the mocked PCS
+    # response must also reflect bedtime being enabled, or the second chunk
+    # would see it revert to the fixture's disabled default.
+    pcs_response = await load_fixture("device_parental_control_setting")
+    pcs_response["parentalControlSetting"]["playTimerRegulations"]["dailyRegulations"]["bedtime"] = {
+        "enabled": True,
+        "endingTime": {"hour": 21, "minute": 0},
+        "startingTime": {"hour": 6, "minute": 0},
+    }
+    mock_api.async_get_device_parental_control_setting.return_value = {"json": pcs_response}
+    mock_api.async_confirm_extra_playing_time.return_value = None
+
+    with patch("pynintendoparental.device.asyncio.sleep", new=AsyncMock()):
+        await device.add_extra_time(90)
+
+    assert mock_api.async_confirm_extra_playing_time.call_args_list == [
+        call(device.device_id, 60, True),
+        call(device.device_id, 30, True),
+    ]
+    mock_api.async_update_extra_playing_time.assert_not_called()
+
+
+async def test_add_extra_time_recomputes_with_bedtime_per_chunk(mock_api: Api):
+    """with_bedtime must be recomputed each chunk, not frozen once before the loop.
+
+    Each chunk already pays for a fresh _get_parental_control_setting fetch;
+    if bedtime becomes active partway through a batch, later chunks must use
+    the refreshed state for their dispatch decision instead of ignoring it.
+    """
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    assert device.bedtime_alarm == time(0, 0)  # starts disabled per fixture
+
+    pcs_response = await load_fixture("device_parental_control_setting")
+    bedtime_on_response = copy.deepcopy(pcs_response)
+    bedtime_on_response["parentalControlSetting"]["playTimerRegulations"]["dailyRegulations"]["bedtime"] = {
+        "enabled": True,
+        "endingTime": {"hour": 21, "minute": 0},
+        "startingTime": {"hour": 6, "minute": 0},
+    }
+    mock_api.async_get_device_parental_control_setting.return_value = {"json": bedtime_on_response}
+    mock_api.async_update_extra_playing_time.return_value = None
+    mock_api.async_confirm_extra_playing_time.return_value = None
+
+    with patch("pynintendoparental.device.asyncio.sleep", new=AsyncMock()):
+        await device.add_extra_time(90)
+
+    # First chunk: bedtime was still disabled at dispatch time.
+    mock_api.async_update_extra_playing_time.assert_called_once_with(device.device_id, 60)
+    # The refetch after chunk 1 revealed bedtime is now active; chunk 2 must
+    # use that, not the frozen pre-loop decision.
+    mock_api.async_confirm_extra_playing_time.assert_called_once_with(device.device_id, 30, True)
+
+
+async def test_add_extra_time_executes_callbacks(mock_api: Api):
+    """add_extra_time must fire device callbacks so consumers (e.g. HA entities) refresh promptly."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    mock_api.async_update_extra_playing_time.return_value = None
+    callback = AsyncMock()
+    device.add_device_callback(callback)
+
+    await device.add_extra_time(15)
+
+    callback.assert_awaited_once()
+
+
+async def test_add_extra_time_converts_float_to_int(mock_api: Api):
+    """A float minutes value (e.g. from a Home Assistant numeric state) must be
+    converted to int before being sent to the API, matching update_max_daily_playtime
+    and set_daily_restrictions - the API would otherwise likely 400 on a float."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    mock_api.async_update_extra_playing_time.return_value = None
+
+    await device.add_extra_time(30.0)
+
+    mock_api.async_update_extra_playing_time.assert_called_once_with(device.device_id, 30)
+    sent_minutes = mock_api.async_update_extra_playing_time.call_args.args[1]
+    assert type(sent_minutes) is int  # noqa: E721 - explicitly checking for int, not just == 30
+
+
+async def test_add_extra_time_rejects_values_below_minus_one(mock_api: Api):
+    """Any value less than -1 is invalid and must raise immediately without an API call."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+
+    with pytest.raises(ValueError):
+        await device.add_extra_time(-5)
+
+    mock_api.async_update_extra_playing_time.assert_not_called()
+    mock_api.async_confirm_extra_playing_time.assert_not_called()
+
+
+async def test_add_extra_time_fires_callbacks_after_partial_batch_failure(mock_api: Api):
+    """If a chunk's API call fails partway through a batch, callbacks must still fire
+    so consumers (e.g. Home Assistant entities) reflect whatever chunks did apply,
+    even though the exception propagates to the caller."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    device = devices[0]
+    mock_api.async_update_extra_playing_time.side_effect = [None, HttpException(500, "boom")]
+    callback = AsyncMock()
+    device.add_device_callback(callback)
+
+    with patch("pynintendoparental.device.asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(HttpException):
+            await device.add_extra_time(130)  # 3 chunks: 60, 60, 10 - second chunk fails
+
+    callback.assert_awaited_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Had to open a new PR for this. See #132 for context and review requests. This is initially just a rebase against main -- no review requests have been addressed yet.

Claude says:

---

Reopening #132 against `main` — its old base branch (`fix/ha-167425`) was deleted after #121 merged, which auto-closed it and GitHub won't allow reopening or retargeting a closed PR once the base ref is gone.

The branch itself needs no changes: its parent commit is already an ancestor of `main` (via #121), so the diff against `main` is byte-identical to what #132 showed against `fix/ha-167425`.

## Summary

Batches requests over 60 minutes. A single `additionalTime > 60` is rejected outright by Nintendo's server (`HTTP 400: additionalTime must be less than or equal to 60`), matching the largest preset in the app's own UI (5/15/30/60 minutes, plus unlimited). `add_extra_time` now transparently splits larger requests into multiple ≤60-minute calls (e.g. 130 → 60+60+10), paced 2 seconds apart. The bedtime-aware dispatch decision (confirm vs. update endpoint) is recomputed fresh for every chunk rather than frozen once, since each chunk already triggers a state refetch — so a bedtime change mid-batch is picked up for the remaining chunks.

Also:
- Fires device callbacks from `add_extra_time` via `try/finally`, so consumers (e.g. the Home Assistant integration) still refresh even if a chunk fails partway through a batch.
- Converts a float `minutes` value to `int` and raises `ValueError` for `minutes < -1`, matching the existing pattern in `update_max_daily_playtime`.

## Testing

- 104 unit tests, `black`/`isort`/`flake8`/`bandit` clean (2 pre-existing formatting issues in files this PR doesn't touch are unaffected, confirmed identical on `main`).
- Verified live against a real Switch: a 130-minute grant confirmed to apply additively as 60+60+10 across three real API calls.
- Full test log/results and the custom Home Assistant integration this was validated against: https://github.com/deargle/ha-nintendo-parental-controls

## Notes for reviewers

- Replaces #132 (same branch, same commit, no changes) — only the base branch differs, since `fix/ha-167425` was deleted post-merge.
- Split from #129 alongside #131 (guard/cancel_extra_time), per feedback to unsquash into one change per PR.
