### PR TITLE
Enhance player and application management with new registries and data classes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
         "tests"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
+    "python.testing.pytestEnabled": true,
+    "python.terminal.useEnvFile": true
 }

--- a/pynintendoparental/application.py
+++ b/pynintendoparental/application.py
@@ -1,9 +1,10 @@
 """A Nintendo application."""
 
-from dataclasses import dataclass
 import copy
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from .api import Api
 from .const import _LOGGER
@@ -56,7 +57,7 @@ class Application:
         self._parental_control_settings: dict = {}
         self._monthly_summary: dict = {}
         self._daily_summary: dict = {}
-        self._device: "Device" | None = None
+        self._device: Device | None = None
 
         # Register internal callbacks
         callbacks.append(self._internal_update_callback)
@@ -174,6 +175,53 @@ class Application:
             raise ValueError("Callback not found.")
         self._callbacks.remove(callback)
 
+
+class ApplicationRegistry:
+    """Registry of applications for a device."""
+
+    def __init__(self):
+        """Initialise the application registry."""
+        self._applications: list[Application] = []
+        self._application_ids: set[str] = set()
+
+    def __contains__(self, application_id: str) -> bool:
+        """Check if an application is in the registry."""
+        return application_id in self._application_ids
+
+    def __len__(self) -> int:
+        """Get the number of applications in the registry."""
+        return len(self._applications)
+
+    def __iter__(self):
+        """Iterate over the applications in the registry."""
+        yield from self._applications
+
+    def get_application(self, application_id: str) -> Application:
+        """Get an application by its ID."""
+        if application_id not in self._application_ids:
+            raise ValueError(f"Application {application_id} not found.")
+        return self._applications.get(application_id)
+
+    def get_application_by_name(self, name: str) -> Application:
+        """Get an application by its name."""
+        for application in self._applications:
+            if application.name == name:
+                return application
+        raise ValueError(f"Application {name} not found.")
+
+    def add_application(self, application: Application):
+        """Add an application to the registry."""
+        if application.application_id in self._application_ids:
+            raise ValueError(f"Application {application.application_id} already in registry.")
+        self._applications.append(application)
+        self._application_ids.add(application.application_id)
+
+    def remove_application(self, application_id: str):
+        """Remove an application from the registry."""
+        if application_id not in self._application_ids:
+            raise ValueError(f"Application {application_id} not found.")
+        self._applications.remove(self.get_application(application_id))
+        self._application_ids.remove(application_id)
 
 @dataclass(frozen=True, slots=True)
 class PlayedAppUsage:

--- a/pynintendoparental/application.py
+++ b/pynintendoparental/application.py
@@ -200,7 +200,9 @@ class ApplicationRegistry:
         """Get an application by its ID."""
         if application_id not in self._application_ids:
             raise ValueError(f"Application {application_id} not found.")
-        return self._applications.get(application_id)
+        for application in self._applications:
+            if application.application_id == application_id:
+                return application
 
     def get_application_by_name(self, name: str) -> Application:
         """Get an application by its name."""

--- a/pynintendoparental/application.py
+++ b/pynintendoparental/application.py
@@ -62,6 +62,12 @@ class Application:
         # Register internal callbacks
         callbacks.append(self._internal_update_callback)
 
+    def __eq__(self, other: object) -> bool:
+        """Check if the application is equal to another object."""
+        if not isinstance(other, Application):
+            return False
+        return self.application_id == other.application_id and self.name == other.name
+
     async def set_safe_launch_setting(self, safe_launch_setting: SafeLaunchSetting):
         """Set the application's status on the Allow List.
 
@@ -225,7 +231,8 @@ class ApplicationRegistry:
         self._applications.remove(self.get_application(application_id))
         self._application_ids.remove(application_id)
 
-@dataclass(frozen=True, slots=True)
+
+@dataclass(frozen=True, slots=True, repr=False)
 class PlayedAppUsage:
     """Usage information for a played application for a given player."""
 

--- a/pynintendoparental/application.py
+++ b/pynintendoparental/application.py
@@ -1,5 +1,6 @@
 """A Nintendo application."""
 
+from dataclasses import dataclass
 import copy
 from datetime import datetime
 from typing import TYPE_CHECKING, Callable
@@ -172,3 +173,11 @@ class Application:
         if callback not in self._callbacks:
             raise ValueError("Callback not found.")
         self._callbacks.remove(callback)
+
+
+@dataclass(frozen=True, slots=True)
+class PlayedAppUsage:
+    """Usage information for a played application for a given player."""
+
+    application: Application
+    playing_time: int

--- a/pynintendoparental/device/_callbacks.py
+++ b/pynintendoparental/device/_callbacks.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from datetime import datetime
-from typing import TYPE_CHECKING, Callable
+from collections.abc import Callable
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 from ..utils import is_awaitable
 
@@ -27,10 +28,10 @@ class DeviceCallbacksMixin:
             callback: A callable function. Can be sync or async.
 
         Raises:
-            ValueError: If the provided object is not callable.
+            TypeError: If the provided object is not callable.
         """
         if not callable(callback):
-            raise ValueError("Object must be callable.")
+            raise TypeError("Object must be callable.")
         if callback not in self._callbacks:
             self._callbacks.append(callback)
 
@@ -41,10 +42,10 @@ class DeviceCallbacksMixin:
             callback: The callback function to remove.
 
         Raises:
-            ValueError: If the provided object is not callable or not found.
+            TypeError: If the provided object is not callable or not found.
         """
         if not callable(callback):
-            raise ValueError("Object must be callable.")
+            raise TypeError("Object must be callable.")
         if callback in self._callbacks:
             self._callbacks.remove(callback)
 
@@ -62,9 +63,14 @@ class DeviceCallbacksMixin:
             else:
                 cb()
 
-    async def _send_api_update(self: Device, api_call: Callable, *args, **kwargs) -> None:  # type: ignore[misc]
+    async def _send_api_update(  # type: ignore[misc]
+        self: Device,
+        api_call: Callable,
+        *args,
+        **kwargs,
+    ) -> None:
         """Sends an update to the API and refreshes local state."""
-        now = kwargs.pop("now", datetime.now())
+        now = kwargs.pop("now", datetime.now(timezone.utc))
         response = await api_call(*args, **kwargs)
         self._parse_parental_control_setting(response["json"], now)
         self._calculate_times(now)

--- a/pynintendoparental/device/_core.py
+++ b/pynintendoparental/device/_core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from datetime import datetime, time, timedelta
+from datetime import datetime, time, timedelta, timezone
 
 from pynintendoauth.exceptions import (
     HttpException,
@@ -126,7 +126,7 @@ class Device(
         """
         _LOGGER.debug(">> Device.update()")
         if now is None:
-            now = datetime.now()
+            now = datetime.now(timezone.utc)
         await asyncio.gather(
             self._get_daily_summaries(now),
             self.get_monthly_summary(),
@@ -236,7 +236,7 @@ class Device(
         search_date = datetime.strptime(
             f"{available_summary['year']}-{available_summary['month']}-01",
             "%Y-%m-%d",
-        )
+        ).astimezone(None)
         _LOGGER.debug("Using search date %s for monthly summary request", search_date)
         return search_date
 
@@ -286,7 +286,7 @@ class Device(
             ValueError: If no summary exists for the given date or no summaries are available.
         """
         if input_date is None:
-            input_date = datetime.now()
+            input_date = datetime.now(timezone.utc)
         if not self.daily_summaries:
             raise ValueError("No daily summaries available to search.")
         summary = [x for x in self.daily_summaries if x["date"] == input_date.strftime("%Y-%m-%d")]

--- a/pynintendoparental/device/_core.py
+++ b/pynintendoparental/device/_core.py
@@ -135,9 +135,10 @@ class Device(
         # Fetch PCS after daily summaries so extra_playing_time is not parsed from a
         # stale concurrent response (see #118 / debug-430f96).
         await self._get_parental_control_setting(now)
+        self._update_applications()
+        self._hydrate_players_from_monthly_summary(self.last_month_summary)
         for player in self.players:
             player.update_from_daily_summary(self.daily_summaries, self.applications)
-        self._update_applications()
         await self._execute_callbacks()
 
     def _update_applications(self):
@@ -215,7 +216,6 @@ class Device(
             return None
         if latest:
             self.last_month_summary = summary
-            self._hydrate_players_from_monthly_summary(summary)
         return summary
 
     async def _resolve_latest_monthly_summary_date(self) -> datetime | None:

--- a/pynintendoparental/device/_core.py
+++ b/pynintendoparental/device/_core.py
@@ -4,16 +4,18 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from datetime import datetime, time, timedelta
-from typing import Callable
 
-from pynintendoauth.exceptions import HttpException  # type: ignore[import-untyped]  # pylint: disable=import-error
+from pynintendoauth.exceptions import (
+    HttpException,
+)
 
 from ..api import Api
-from ..application import Application
+from ..application import Application, ApplicationRegistry
 from ..const import _LOGGER, DAYS_OF_WEEK
 from ..enum import AlarmSettingState, DeviceTimerMode
-from ..player import Player
+from ..player import Player, PlayerRegistry
 from ._callbacks import DeviceCallbacksMixin
 from ._parsing import DeviceParsingMixin
 from ._settings import DeviceSettingsMixin
@@ -59,7 +61,7 @@ class Device(
         self._api: Api = api
         self.daily_summaries: list = []
         self.parental_control_settings: dict = {}
-        self.players: dict[str, Player] = {}
+        self.players: PlayerRegistry = PlayerRegistry()
         self.limit_time: int | float | None = 0
         self.extra_playing_time: int | None = None
         self.timer_mode: DeviceTimerMode | None = None
@@ -74,7 +76,7 @@ class Device(
         self.today_important_info: list = []
         self.today_observations: list = []
         self.last_month_summary: dict = {}
-        self.applications: dict[str, Application] = {}
+        self.applications: ApplicationRegistry = ApplicationRegistry()
         self.whitelisted_applications: dict[str, bool] = {}
         self.last_month_playing_time: int = 0
         self.forced_termination_mode: bool = False
@@ -134,8 +136,8 @@ class Device(
         # Fetch PCS after daily summaries so extra_playing_time is not parsed from a
         # stale concurrent response (see #118 / debug-430f96).
         await self._get_parental_control_setting(now)
-        for player in self.players.values():
-            player.update_from_daily_summary(self.daily_summaries)
+        for player in self.players:
+            player.update_from_daily_summary(self.daily_summaries, self.applications)
         self._update_applications()
         await self._execute_callbacks()
 
@@ -143,16 +145,15 @@ class Device(
         """Updates applications from whitelisted applications list."""
         _LOGGER.debug(">> Device._update_applications()")
         for app in self.parental_control_settings.get("whitelistedApplicationList", []):
-            if app["applicationId"] in self.applications:
-                continue
-            self.applications[app["applicationId"]] = Application(
-                app_id=app["applicationId"],
-                name=app["title"],
-                device_id=self.device_id,
-                api=self._api,
-                send_api_update=self._send_api_update,
-                callbacks=self._internal_callbacks,
-            )
+            if app["applicationId"] not in self.applications:
+                self.applications.add_application(Application(
+                    app_id=app["applicationId"],
+                    name=app["title"],
+                    device_id=self.device_id,
+                    api=self._api,
+                    send_api_update=self._send_api_update,
+                    callbacks=self._internal_callbacks,
+                ))
 
     def _get_today_regulation(self, now: datetime) -> dict:
         """Returns the regulation settings for the current day."""
@@ -270,8 +271,8 @@ class Device(
                 continue
             player_id = profile["playerId"]
             if player_id not in self.players:
-                self.players[player_id] = Player.from_profile(profile)
-            self.players[player_id].month_summary = player.get("summary", {})
+                self.players.add_player(Player.from_profile(profile))
+            self.players.get_player(player_id).month_summary = player.get("summary", {})
 
     def get_date_summary(self, input_date: datetime | None = None) -> list:
         """Get the usage summary for a specific date.
@@ -300,21 +301,18 @@ class Device(
     def get_application(self, application_id: str) -> Application:
         """Get an Application object by its application ID."""
         if application_id in self.applications:
-            return self.applications[application_id]
+            return self.applications.get_application(application_id)
         raise ValueError(f"Application with id {application_id} not found.")
 
     def get_player(self, player_id: str) -> Player:
         """Get a Player object by player ID."""
-        player = self.players.get(player_id)
-        if player:
-            return player
-        raise ValueError(f"Player with id {player_id} not found.")
+        return self.players.get_player(player_id)
 
     @classmethod
     async def from_devices_response(cls, raw: dict, api: Api, now: datetime | None = None) -> list[Device]:
         """Parses a device request response body."""
         _LOGGER.debug("Parsing device list response")
-        if "ownedDevices" not in raw.keys():
+        if "ownedDevices" not in raw:
             raise ValueError("Invalid response from API.")
         devices = []
         for device in raw.get("ownedDevices", []):
@@ -332,7 +330,7 @@ class Device(
     def from_device_response(cls, raw: dict, api: Api) -> Device:
         """Parses a single device request response body."""
         _LOGGER.debug("Parsing device response")
-        if "deviceId" not in raw.keys():
+        if "deviceId" not in raw:
             raise ValueError("Invalid response from API.")
 
         parsed = Device(api)

--- a/pynintendoparental/device/_core.py
+++ b/pynintendoparental/device/_core.py
@@ -77,7 +77,6 @@ class Device(
         self.today_observations: list = []
         self.last_month_summary: dict = {}
         self.applications: ApplicationRegistry = ApplicationRegistry()
-        self.whitelisted_applications: dict[str, bool] = {}
         self.last_month_playing_time: int = 0
         self.forced_termination_mode: bool = False
         self.alarms_enabled: bool = False

--- a/pynintendoparental/device/_times.py
+++ b/pynintendoparental/device/_times.py
@@ -38,6 +38,10 @@ def remaining_play_minutes(
 
     if bedtime_alarm and not is_bedtime_disabled(bedtime_alarm) and alarms_enabled:
         bedtime_dt = datetime.combine(now.date(), bedtime_alarm)
+        if now.tzinfo is not None and bedtime_dt.tzinfo is None:
+            bedtime_dt = bedtime_dt.replace(tzinfo=now.tzinfo)
+        elif now.tzinfo is None and bedtime_dt.tzinfo is not None:
+            bedtime_dt = bedtime_dt.replace(tzinfo=None)
         if bedtime_dt <= now and bedtime_alarm.hour < 6 and now.hour >= 6:
             bedtime_dt += timedelta(days=1)
         if bedtime_dt > now:

--- a/pynintendoparental/player.py
+++ b/pynintendoparental/player.py
@@ -1,8 +1,34 @@
 """Nintendo Player."""
 
-from .application import PlayedAppUsage
+from .application import ApplicationRegistry, PlayedAppUsage
 from .const import _LOGGER
 
+
+def parse_played_apps(raw: list[dict], app_registry: ApplicationRegistry) -> list[PlayedAppUsage]:
+    """Parse the played apps from a daily summary response.
+
+    Args:
+        raw: List of daily summary dictionaries from the API.
+        app_registry: Application registry to use to parse the played apps.
+    Returns:
+        List of PlayedAppUsage objects parsed from the summary.
+    """
+    result = []
+    for entry in raw:
+        # Handle both platform generations
+        app_id = (
+            entry.get("applicationId") or
+            entry.get("meta", {}).get("applicationId")
+        )
+        if not app_id:
+            continue
+        result.append(
+            PlayedAppUsage(
+                application=app_registry.get_application(app_id),
+                playing_time=entry.get("playingTime"),
+            )
+        )
+    return result
 
 class Player:
     """A Nintendo Switch user profile.
@@ -27,11 +53,12 @@ class Player:
         self.player_id: str | None = None
         self.playing_time: int = 0
 
-    def update_from_daily_summary(self, raw: list[dict]):
+    def update_from_daily_summary(self, raw: list[dict], app_registry: ApplicationRegistry):
         """Update player data from a daily summary response.
 
         Args:
             raw: List of daily summary dictionaries from the API.
+            app_registry: Application registry to use to parse the played apps.
         """
         _LOGGER.debug("Updating player %s daily summary", self.player_id)
         for player in raw[0].get("players", []):
@@ -39,32 +66,11 @@ class Player:
                 self.player_image = player["profile"].get("imageUri")
                 self.nickname = player["profile"].get("nickname")
                 self.playing_time = player.get("playingTime")
-                self.apps = player.get("playedGames")
+                self.apps = parse_played_apps(player.get("playedGames"), app_registry)
                 break
 
-    def _parse_played_apps(self, raw: list[dict]) -> list[PlayedAppUsage]:
-        """Parse the played apps from a daily summary response.
-
-        Args:
-            raw: List of daily summary dictionaries from the API.
-
-        Returns:
-            List of PlayedAppUsage objects parsed from the summary.
-        """
-        result = []
-        for entry in raw:
-            # Handle both platform generations
-            app_id = (
-                entry.get("applicationId") or
-                entry.get("meta", {}).get("applicationId")
-            )
-            if not app_id:
-                continue
-            result.append(PlayedAppUsage(application=None, playing_time=entry.get("playingTime")))
-        return result
-
     @classmethod
-    def from_device_daily_summary(cls, raw: list[dict]) -> list["Player"]:
+    def from_device_daily_summary(cls, raw: list[dict], app_registry: ApplicationRegistry) -> list["Player"]:
         """Create Player objects from a device daily summary response.
 
         Args:
@@ -81,7 +87,10 @@ class Player:
             parsed.player_image = player["profile"].get("imageUri")
             parsed.nickname = player["profile"].get("nickname")
             parsed.playing_time = player.get("playingTime")
-            parsed.apps = player.get("playedGames")
+            parsed.apps = parse_played_apps(
+                player.get("playedGames"),
+                app_registry,
+            )
             players.append(parsed)
             _LOGGER.debug("Built player %s", parsed.player_id)
         return players
@@ -101,3 +110,46 @@ class Player:
         parsed.player_image = raw.get("imageUri")
         parsed.nickname = raw.get("nickname")
         return parsed
+
+class PlayerRegistry:
+    """Registry of players for a device."""
+
+    def __init__(self):
+        """Initialise the player registry."""
+        self._players: list[Player] = []
+        self._player_ids: set[str] = set()
+
+    def __contains__(self, player_id: str) -> bool:
+        """Check if a player is in the registry."""
+        return player_id in self._player_ids
+
+    def __len__(self) -> int:
+        """Get the number of players in the registry."""
+        return len(self._players)
+
+    def __iter__(self) -> Player:
+        """Iterate over the players in the registry."""
+        yield from self._players
+
+    def get_player(self, player_id: str) -> Player:
+        """Get a player by its ID."""
+        if player_id not in self._player_ids:
+            raise ValueError(f"Player {player_id} not found.")
+        for player in self._players:
+            if player.player_id == player_id:
+                return player
+        raise ValueError(f"Player {player_id} not found.")
+
+    def add_player(self, player: Player):
+        """Add a player to the registry."""
+        if player.player_id in self._player_ids:
+            raise ValueError(f"Player {player.player_id} already in registry.")
+        self._players.append(player)
+        self._player_ids.add(player.player_id)
+
+    def remove_player(self, player_id: str):
+        """Remove a player from the registry."""
+        if player_id not in self._player_ids:
+            raise ValueError(f"Player {player_id} not found.")
+        self._players.remove(self.get_player(player_id))
+        self._player_ids.remove(player_id)

--- a/pynintendoparental/player.py
+++ b/pynintendoparental/player.py
@@ -1,5 +1,6 @@
 """Nintendo Player."""
 
+from .application import PlayedAppUsage
 from .const import _LOGGER
 
 
@@ -21,7 +22,7 @@ class Player:
         """Init a player."""
         self.player_image: str | None = None
         self.nickname: str | None = None
-        self.apps: list = []
+        self.apps: list[PlayedAppUsage] = []
         self.month_summary: dict = {}
         self.player_id: str | None = None
         self.playing_time: int = 0
@@ -40,6 +41,27 @@ class Player:
                 self.playing_time = player.get("playingTime")
                 self.apps = player.get("playedGames")
                 break
+
+    def _parse_played_apps(self, raw: list[dict]) -> list[PlayedAppUsage]:
+        """Parse the played apps from a daily summary response.
+
+        Args:
+            raw: List of daily summary dictionaries from the API.
+
+        Returns:
+            List of PlayedAppUsage objects parsed from the summary.
+        """
+        result = []
+        for entry in raw:
+            # Handle both platform generations
+            app_id = (
+                entry.get("applicationId") or
+                entry.get("meta", {}).get("applicationId")
+            )
+            if not app_id:
+                continue
+            result.append(PlayedAppUsage(application=None, playing_time=entry.get("playingTime")))
+        return result
 
     @classmethod
     def from_device_daily_summary(cls, raw: list[dict]) -> list["Player"]:

--- a/pynintendoparental/player.py
+++ b/pynintendoparental/player.py
@@ -70,7 +70,11 @@ class Player:
                 break
 
     @classmethod
-    def from_device_daily_summary(cls, raw: list[dict], app_registry: ApplicationRegistry) -> list["Player"]:
+    def from_device_daily_summary(
+        cls,
+        raw: list[dict],
+        app_registry: ApplicationRegistry,
+    ) -> list["Player"]:
         """Create Player objects from a device daily summary response.
 
         Args:

--- a/pynintendoparental/player.py
+++ b/pynintendoparental/player.py
@@ -148,6 +148,13 @@ class PlayerRegistry:
             if player.player_id == player_id:
                 return player
 
+    def get(self, player_id: str) -> Player | None:
+        """Compatibility method for getting a player by its ID."""
+        try:
+            return self.get_player(player_id)
+        except ValueError:
+            return None
+
     def add_player(self, player: Player):
         """Add a player to the registry."""
         if player.player_id in self._player_ids:

--- a/pynintendoparental/player.py
+++ b/pynintendoparental/player.py
@@ -22,9 +22,14 @@ def parse_played_apps(raw: list[dict], app_registry: ApplicationRegistry) -> lis
         )
         if not app_id:
             continue
+        try:
+            app = app_registry.get_application(app_id)
+        except ValueError:
+            _LOGGER.warning("Application %s not found in registry, skipping.", app_id)
+            continue
         result.append(
             PlayedAppUsage(
-                application=app_registry.get_application(app_id),
+                application=app,
                 playing_time=entry.get("playingTime"),
             )
         )
@@ -142,7 +147,6 @@ class PlayerRegistry:
         for player in self._players:
             if player.player_id == player_id:
                 return player
-        raise ValueError(f"Player {player_id} not found.")
 
     def add_player(self, player: Player):
         """Add a player to the registry."""

--- a/test.py
+++ b/test.py
@@ -56,7 +56,7 @@ async def main():
 
 if __name__ == "__main__":
     logging.basicConfig(
-        level=logging.INFO,
+        level=logging.DEBUG,
         format="%(asctime)s %(name)s %(levelname)s: %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )

--- a/test.py
+++ b/test.py
@@ -1,13 +1,11 @@
-import os
-import logging
 import asyncio
-
-from datetime import time
+import logging
+import os
 
 from dotenv import load_dotenv
 from pynintendoauth.exceptions import InvalidSessionTokenException
+
 from pynintendoparental import Authenticator, NintendoParental
-from pynintendoparental.enum import FunctionalRestrictionLevel
 
 load_dotenv()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,10 @@ import pytest
 
 from pynintendoparental import NintendoParental
 from pynintendoparental.api import Api
+from pynintendoparental.application import ApplicationRegistry
 from pynintendoparental.authenticator import Authenticator
 from pynintendoparental.device import Device
+from pynintendoparental.player import PlayerRegistry
 
 from .helpers import load_fixture
 
@@ -66,3 +68,13 @@ def mock_client(mock_api: Api) -> NintendoParental:
     client = create_autospec(NintendoParental)
     client._api = mock_api
     return client
+
+@pytest.fixture
+async def app_registry(device: Device) -> ApplicationRegistry:
+    """Fixture for a mocked application registry."""
+    return device.applications
+
+@pytest.fixture
+def player_registry() -> PlayerRegistry:
+    """Fixture for a mocked player registry."""
+    return PlayerRegistry()

--- a/tests/fixtures/multiple_devices.json
+++ b/tests/fixtures/multiple_devices.json
@@ -1,0 +1,5519 @@
+{
+  "Device 1 (P01)": {
+    "name": "Device 1",
+    "model": "Switch 2",
+    "generation": "P01",
+    "daily_summaries": [
+      {
+        "date": "2026-08-17",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-08-16",
+        "result": "ACHIEVED",
+        "playingTime": 70,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 3,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 70,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 70
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 70,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 70
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-08-15",
+        "result": "ACHIEVED",
+        "playingTime": 65,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 60,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 60
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 60,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 60
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-08-14",
+        "result": "ACHIEVED",
+        "playingTime": 70,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 70,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 70
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 70,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 70
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-08-13",
+        "result": "ACHIEVED",
+        "playingTime": 65,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 65,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 65
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 65,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 65
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-08-12",
+        "result": "ACHIEVED",
+        "playingTime": 70,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 70,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 70
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 65,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 65
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-08-11",
+        "result": "ACHIEVED",
+        "playingTime": 40,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 40,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 40
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 40,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 40
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-08-10",
+        "result": "ACHIEVED",
+        "playingTime": 115,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "nonFeaturedGameCount": 1,
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 75,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 75
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-3",
+              "nickname": "Player 3",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-3"
+            },
+            "playingTime": 35,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "01004FF021942000",
+                  "title": "EA SPORTS FC 26",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/54d07ce12da440b598e0e380611fba8a_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/54d07ce12da440b598e0e380611fba8a_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/54d07ce12da440b598e0e380611fba8a_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/54d07ce12da440b598e0e380611fba8a_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/54d07ce12da440b598e0e380611fba8a_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/01004ff021942000/DE?lang=de-DE"
+                },
+                "playingTime": 35
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 15,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 15
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-08-09",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-08-08",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-08-07",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-08-06",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-08-05",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-08-04",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-08-03",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-08-02",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-08-01",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-31",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-30",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-29",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-28",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-27",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-26",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-25",
+        "result": "ACHIEVED",
+        "playingTime": 70,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 70,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 70
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 70,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 70
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-24",
+        "result": "ACHIEVED",
+        "playingTime": 40,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 40,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 40
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 40,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 40
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-23",
+        "result": "ACHIEVED",
+        "playingTime": 50,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 50,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 50
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 50,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 50
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-22",
+        "result": "ACHIEVED",
+        "playingTime": 45,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 45,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 45
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 45,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 45
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-21",
+        "result": "ACHIEVED",
+        "playingTime": 3,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 3,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 3
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-20",
+        "result": "ACHIEVED",
+        "playingTime": 55,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 55,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 55
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 55,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 55
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-19",
+        "result": "ACHIEVED",
+        "playingTime": 70,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 70,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 70
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 65,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 65
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-18",
+        "result": "ACHIEVED",
+        "playingTime": 65,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-1",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-1"
+            },
+            "playingTime": 65,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 65
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          },
+          {
+            "profile": {
+              "playerId": "player-2",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": "nsa-2"
+            },
+            "playingTime": 65,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 65
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      }
+    ],
+    "last_month_summary": {
+      "overall": {
+        "stat": {
+          "totalDays": 18,
+          "averageTime": 55
+        },
+        "dailyStats": [
+          {
+            "date": "2026-07-01",
+            "totalTime": 55,
+            "games": {
+              "010086000E148000": {
+                "totalTime": 50
+              }
+            }
+          },
+          {
+            "date": "2026-07-02",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-07-03",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-07-04",
+            "totalTime": 50,
+            "games": {
+              "01006000040C2000": {
+                "totalTime": 50
+              }
+            }
+          },
+          {
+            "date": "2026-07-05",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-07-06",
+            "totalTime": 80,
+            "games": {
+              "01006000040C2000": {
+                "totalTime": 80
+              }
+            }
+          },
+          {
+            "date": "2026-07-07",
+            "totalTime": 60,
+            "games": {
+              "01006000040C2000": {
+                "totalTime": 60
+              }
+            }
+          },
+          {
+            "date": "2026-07-08",
+            "totalTime": 65,
+            "games": {
+              "01006000040C2000": {
+                "totalTime": 65
+              }
+            }
+          },
+          {
+            "date": "2026-07-09",
+            "totalTime": 55,
+            "games": {
+              "01006000040C2000": {
+                "totalTime": 55
+              }
+            }
+          },
+          {
+            "date": "2026-07-10",
+            "totalTime": 35,
+            "games": {
+              "0100D71004694000": {
+                "totalTime": 35
+              }
+            }
+          },
+          {
+            "date": "2026-07-11",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-07-12",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-07-13",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-07-14",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-07-15",
+            "totalTime": 70,
+            "games": {
+              "0100D71004694000": {
+                "totalTime": 70
+              }
+            }
+          },
+          {
+            "date": "2026-07-16",
+            "totalTime": 85,
+            "games": {
+              "0100D71004694000": {
+                "totalTime": 85
+              }
+            }
+          },
+          {
+            "date": "2026-07-17",
+            "totalTime": 70,
+            "games": {
+              "0100D71004694000": {
+                "totalTime": 70
+              }
+            }
+          },
+          {
+            "date": "2026-07-18",
+            "totalTime": 65,
+            "games": {
+              "0100D71004694000": {
+                "totalTime": 65
+              }
+            }
+          },
+          {
+            "date": "2026-07-19",
+            "totalTime": 70,
+            "games": {
+              "0100D71004694000": {
+                "totalTime": 70
+              }
+            }
+          },
+          {
+            "date": "2026-07-20",
+            "totalTime": 55,
+            "games": {
+              "0100D71004694000": {
+                "totalTime": 55
+              }
+            }
+          },
+          {
+            "date": "2026-07-21",
+            "totalTime": 3,
+            "games": {
+              "0100D71004694000": {
+                "totalTime": 3
+              }
+            }
+          },
+          {
+            "date": "2026-07-22",
+            "totalTime": 45,
+            "games": {
+              "0100D71004694000": {
+                "totalTime": 45
+              }
+            }
+          },
+          {
+            "date": "2026-07-23",
+            "totalTime": 50,
+            "games": {
+              "0100D71004694000": {
+                "totalTime": 50
+              }
+            }
+          },
+          {
+            "date": "2026-07-24",
+            "totalTime": 40,
+            "games": {
+              "0100D71004694000": {
+                "totalTime": 40
+              }
+            }
+          },
+          {
+            "date": "2026-07-25",
+            "totalTime": 70,
+            "games": {
+              "0100D71004694000": {
+                "totalTime": 70
+              }
+            }
+          },
+          {
+            "date": "2026-07-26",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-07-27",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-07-28",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-07-29",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-07-30",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-07-31",
+            "totalTime": 0,
+            "games": {}
+          }
+        ],
+        "ranking": [
+          {
+            "position": "UP",
+            "stat": {
+              "totalDays": 12,
+              "meta": {
+                "applicationId": "0100D71004694000",
+                "title": "Minecraft for Nintendo Switch",
+                "imageUri": {
+                  "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                  "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                  "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512",
+                  "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                  "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256"
+                },
+                "hasUgc": true,
+                "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+              },
+              "players": [
+                {
+                  "playerId": "player-2",
+                  "nickname": "Player 2",
+                  "imageUri": "https://example.invalid/avatar.jpg",
+                  "nsaId": "nsa-2"
+                },
+                {
+                  "playerId": "player-1",
+                  "nickname": "Player 1",
+                  "imageUri": "https://example.invalid/avatar.jpg",
+                  "nsaId": "nsa-1"
+                }
+              ]
+            }
+          },
+          {
+            "position": "NEW",
+            "stat": {
+              "totalDays": 5,
+              "meta": {
+                "applicationId": "01006000040C2000",
+                "title": "Yoshi's Crafted World",
+                "imageUri": {
+                  "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/9e427746a3a04abea0420beb3e65eeca_128",
+                  "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/9e427746a3a04abea0420beb3e65eeca_1024",
+                  "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/9e427746a3a04abea0420beb3e65eeca_512",
+                  "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/9e427746a3a04abea0420beb3e65eeca_3",
+                  "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/9e427746a3a04abea0420beb3e65eeca_256"
+                },
+                "hasUgc": false,
+                "shopUri": "https://ec.nintendo.com/apps/01006000040c2000/DE?lang=de-DE"
+              },
+              "players": [
+                {
+                  "playerId": "player-2",
+                  "nickname": "Player 2",
+                  "imageUri": "https://example.invalid/avatar.jpg",
+                  "nsaId": "nsa-2"
+                }
+              ]
+            }
+          },
+          {
+            "position": "NEW",
+            "stat": {
+              "totalDays": 1,
+              "meta": {
+                "applicationId": "010086000E148000",
+                "title": "MARIO & SONIC BEI DEN OLYMPISCHEN SPIELEN: TOKYO 2020",
+                "imageUri": {
+                  "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/01d576964d764eb49d795518312efad9_128",
+                  "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/01d576964d764eb49d795518312efad9_1024",
+                  "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/01d576964d764eb49d795518312efad9_512",
+                  "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/01d576964d764eb49d795518312efad9_3",
+                  "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/01d576964d764eb49d795518312efad9_256"
+                },
+                "hasUgc": false,
+                "shopUri": "https://ec.nintendo.com/apps/010086000e148000/DE?lang=de-DE"
+              },
+              "players": [
+                {
+                  "playerId": "player-2",
+                  "nickname": "Player 2",
+                  "imageUri": "https://example.invalid/avatar.jpg",
+                  "nsaId": "nsa-2"
+                }
+              ]
+            }
+          }
+        ],
+        "chat": {
+          "players": []
+        }
+      },
+      "players": [
+        {
+          "profile": {
+            "playerId": "player-4",
+            "nickname": "Player 4",
+            "imageUri": "https://example.invalid/avatar.jpg",
+            "nsaId": "nsa-4"
+          },
+          "summary": {
+            "stat": {
+              "totalDays": 0,
+              "averageTime": 0
+            },
+            "dailyStats": [
+              {
+                "date": "2026-07-01",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-02",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-03",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-04",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-05",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-06",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-07",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-08",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-09",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-10",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-11",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-12",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-13",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-14",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-15",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-16",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-17",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-18",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-19",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-20",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-21",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-22",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-23",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-24",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-25",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-26",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-27",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-28",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-29",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-30",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-31",
+                "totalTime": 0,
+                "games": {}
+              }
+            ],
+            "ranking": [],
+            "chat": {
+              "members": []
+            }
+          }
+        },
+        {
+          "profile": {
+            "playerId": "player-5",
+            "nickname": "Player 5",
+            "imageUri": "https://example.invalid/avatar.jpg",
+            "nsaId": null
+          },
+          "summary": {
+            "stat": {
+              "totalDays": 0,
+              "averageTime": 0
+            },
+            "dailyStats": [
+              {
+                "date": "2026-07-01",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-02",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-03",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-04",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-05",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-06",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-07",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-08",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-09",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-10",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-11",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-12",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-13",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-14",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-15",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-16",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-17",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-18",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-19",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-20",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-21",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-22",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-23",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-24",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-25",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-26",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-27",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-28",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-29",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-30",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-31",
+                "totalTime": 0,
+                "games": {}
+              }
+            ],
+            "ranking": [],
+            "chat": {
+              "members": []
+            }
+          }
+        },
+        {
+          "profile": {
+            "playerId": "player-2",
+            "nickname": "Player 2",
+            "imageUri": "https://example.invalid/avatar.jpg",
+            "nsaId": "nsa-2"
+          },
+          "summary": {
+            "stat": {
+              "totalDays": 17,
+              "averageTime": 55
+            },
+            "dailyStats": [
+              {
+                "date": "2026-07-01",
+                "totalTime": 50,
+                "games": {
+                  "010086000E148000": {
+                    "totalTime": 50
+                  }
+                }
+              },
+              {
+                "date": "2026-07-02",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-03",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-04",
+                "totalTime": 50,
+                "games": {
+                  "01006000040C2000": {
+                    "totalTime": 50
+                  }
+                }
+              },
+              {
+                "date": "2026-07-05",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-06",
+                "totalTime": 80,
+                "games": {
+                  "01006000040C2000": {
+                    "totalTime": 80
+                  }
+                }
+              },
+              {
+                "date": "2026-07-07",
+                "totalTime": 60,
+                "games": {
+                  "01006000040C2000": {
+                    "totalTime": 60
+                  }
+                }
+              },
+              {
+                "date": "2026-07-08",
+                "totalTime": 65,
+                "games": {
+                  "01006000040C2000": {
+                    "totalTime": 65
+                  }
+                }
+              },
+              {
+                "date": "2026-07-09",
+                "totalTime": 55,
+                "games": {
+                  "01006000040C2000": {
+                    "totalTime": 55
+                  }
+                }
+              },
+              {
+                "date": "2026-07-10",
+                "totalTime": 35,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 35
+                  }
+                }
+              },
+              {
+                "date": "2026-07-11",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-12",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-13",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-14",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-15",
+                "totalTime": 65,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 65
+                  }
+                }
+              },
+              {
+                "date": "2026-07-16",
+                "totalTime": 85,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 85
+                  }
+                }
+              },
+              {
+                "date": "2026-07-17",
+                "totalTime": 65,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 65
+                  }
+                }
+              },
+              {
+                "date": "2026-07-18",
+                "totalTime": 65,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 65
+                  }
+                }
+              },
+              {
+                "date": "2026-07-19",
+                "totalTime": 65,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 65
+                  }
+                }
+              },
+              {
+                "date": "2026-07-20",
+                "totalTime": 55,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 55
+                  }
+                }
+              },
+              {
+                "date": "2026-07-21",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-22",
+                "totalTime": 45,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 45
+                  }
+                }
+              },
+              {
+                "date": "2026-07-23",
+                "totalTime": 50,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 50
+                  }
+                }
+              },
+              {
+                "date": "2026-07-24",
+                "totalTime": 40,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 40
+                  }
+                }
+              },
+              {
+                "date": "2026-07-25",
+                "totalTime": 70,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 70
+                  }
+                }
+              },
+              {
+                "date": "2026-07-26",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-27",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-28",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-29",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-30",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-31",
+                "totalTime": 0,
+                "games": {}
+              }
+            ],
+            "ranking": [
+              {
+                "position": "UP",
+                "stat": {
+                  "totalDays": 11,
+                  "meta": {
+                    "applicationId": "0100D71004694000",
+                    "title": "Minecraft for Nintendo Switch",
+                    "imageUri": {
+                      "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                      "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                      "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512",
+                      "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                      "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256"
+                    },
+                    "hasUgc": true,
+                    "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                  },
+                  "players": [
+                    {
+                      "playerId": "player-2",
+                      "nickname": "Player 2",
+                      "imageUri": "https://example.invalid/avatar.jpg",
+                      "nsaId": "nsa-2"
+                    }
+                  ]
+                }
+              },
+              {
+                "position": "NEW",
+                "stat": {
+                  "totalDays": 5,
+                  "meta": {
+                    "applicationId": "01006000040C2000",
+                    "title": "Yoshi's Crafted World",
+                    "imageUri": {
+                      "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/9e427746a3a04abea0420beb3e65eeca_128",
+                      "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/9e427746a3a04abea0420beb3e65eeca_1024",
+                      "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/9e427746a3a04abea0420beb3e65eeca_512",
+                      "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/9e427746a3a04abea0420beb3e65eeca_3",
+                      "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/9e427746a3a04abea0420beb3e65eeca_256"
+                    },
+                    "hasUgc": false,
+                    "shopUri": "https://ec.nintendo.com/apps/01006000040c2000/DE?lang=de-DE"
+                  },
+                  "players": [
+                    {
+                      "playerId": "player-2",
+                      "nickname": "Player 2",
+                      "imageUri": "https://example.invalid/avatar.jpg",
+                      "nsaId": "nsa-2"
+                    }
+                  ]
+                }
+              },
+              {
+                "position": "NEW",
+                "stat": {
+                  "totalDays": 1,
+                  "meta": {
+                    "applicationId": "010086000E148000",
+                    "title": "MARIO & SONIC BEI DEN OLYMPISCHEN SPIELEN: TOKYO 2020",
+                    "imageUri": {
+                      "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/01d576964d764eb49d795518312efad9_128",
+                      "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/01d576964d764eb49d795518312efad9_1024",
+                      "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/01d576964d764eb49d795518312efad9_512",
+                      "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/01d576964d764eb49d795518312efad9_3",
+                      "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/01d576964d764eb49d795518312efad9_256"
+                    },
+                    "hasUgc": false,
+                    "shopUri": "https://ec.nintendo.com/apps/010086000e148000/DE?lang=de-DE"
+                  },
+                  "players": [
+                    {
+                      "playerId": "player-2",
+                      "nickname": "Player 2",
+                      "imageUri": "https://example.invalid/avatar.jpg",
+                      "nsaId": "nsa-2"
+                    }
+                  ]
+                }
+              }
+            ],
+            "chat": {
+              "members": []
+            }
+          }
+        },
+        {
+          "profile": {
+            "playerId": "player-3",
+            "nickname": "Player 3",
+            "imageUri": "https://example.invalid/avatar.jpg",
+            "nsaId": "nsa-3"
+          },
+          "summary": {
+            "stat": {
+              "totalDays": 0,
+              "averageTime": 0
+            },
+            "dailyStats": [
+              {
+                "date": "2026-07-01",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-02",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-03",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-04",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-05",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-06",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-07",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-08",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-09",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-10",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-11",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-12",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-13",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-14",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-15",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-16",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-17",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-18",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-19",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-20",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-21",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-22",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-23",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-24",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-25",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-26",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-27",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-28",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-29",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-30",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-31",
+                "totalTime": 0,
+                "games": {}
+              }
+            ],
+            "ranking": [],
+            "chat": {
+              "members": []
+            }
+          }
+        },
+        {
+          "profile": {
+            "playerId": "player-1",
+            "nickname": "Player 1",
+            "imageUri": "https://example.invalid/avatar.jpg",
+            "nsaId": "nsa-1"
+          },
+          "summary": {
+            "stat": {
+              "totalDays": 11,
+              "averageTime": 55
+            },
+            "dailyStats": [
+              {
+                "date": "2026-07-01",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-02",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-03",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-04",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-05",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-06",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-07",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-08",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-09",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-10",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-11",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-12",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-13",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-14",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-15",
+                "totalTime": 60,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 60
+                  }
+                }
+              },
+              {
+                "date": "2026-07-16",
+                "totalTime": 85,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 85
+                  }
+                }
+              },
+              {
+                "date": "2026-07-17",
+                "totalTime": 70,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 70
+                  }
+                }
+              },
+              {
+                "date": "2026-07-18",
+                "totalTime": 65,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 65
+                  }
+                }
+              },
+              {
+                "date": "2026-07-19",
+                "totalTime": 70,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 70
+                  }
+                }
+              },
+              {
+                "date": "2026-07-20",
+                "totalTime": 55,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 55
+                  }
+                }
+              },
+              {
+                "date": "2026-07-21",
+                "totalTime": 3,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 3
+                  }
+                }
+              },
+              {
+                "date": "2026-07-22",
+                "totalTime": 45,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 45
+                  }
+                }
+              },
+              {
+                "date": "2026-07-23",
+                "totalTime": 50,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 50
+                  }
+                }
+              },
+              {
+                "date": "2026-07-24",
+                "totalTime": 40,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 40
+                  }
+                }
+              },
+              {
+                "date": "2026-07-25",
+                "totalTime": 70,
+                "games": {
+                  "0100D71004694000": {
+                    "totalTime": 70
+                  }
+                }
+              },
+              {
+                "date": "2026-07-26",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-27",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-28",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-29",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-30",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-31",
+                "totalTime": 0,
+                "games": {}
+              }
+            ],
+            "ranking": [
+              {
+                "position": "UP",
+                "stat": {
+                  "totalDays": 11,
+                  "meta": {
+                    "applicationId": "0100D71004694000",
+                    "title": "Minecraft for Nintendo Switch",
+                    "imageUri": {
+                      "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                      "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                      "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512",
+                      "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                      "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256"
+                    },
+                    "hasUgc": true,
+                    "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                  },
+                  "players": [
+                    {
+                      "playerId": "player-1",
+                      "nickname": "Player 1",
+                      "imageUri": "https://example.invalid/avatar.jpg",
+                      "nsaId": "nsa-1"
+                    }
+                  ]
+                }
+              }
+            ],
+            "chat": {
+              "members": []
+            }
+          }
+        },
+        {
+          "profile": {
+            "playerId": "player-6",
+            "nickname": "Player 6",
+            "imageUri": "https://example.invalid/avatar.jpg",
+            "nsaId": null
+          },
+          "summary": {
+            "stat": {
+              "totalDays": 0,
+              "averageTime": 0
+            },
+            "dailyStats": [
+              {
+                "date": "2026-07-01",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-02",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-03",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-04",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-05",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-06",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-07",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-08",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-09",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-10",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-11",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-12",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-13",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-14",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-15",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-16",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-17",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-18",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-19",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-20",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-21",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-22",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-23",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-24",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-25",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-26",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-27",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-28",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-29",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-30",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-07-31",
+                "totalTime": 0,
+                "games": {}
+              }
+            ],
+            "ranking": [],
+            "chat": {
+              "members": []
+            }
+          }
+        }
+      ]
+    }
+  },
+  "Device 2 (P00)": {
+    "name": "Device 2",
+    "model": "Switch",
+    "generation": "P00",
+    "daily_summaries": [
+      {
+        "date": "2026-07-31",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-30",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-29",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-28",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-27",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-26",
+        "result": "UNACHIEVED",
+        "playingTime": 70,
+        "exceededTime": 70,
+        "disabledTime": 0,
+        "miscTime": 5,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {
+          "addedExtraPlayingTime": true
+        },
+        "featuredGameIconURL": {
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512",
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-7",
+              "nickname": "Player 1",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": null
+            },
+            "playingTime": 65,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512",
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 65
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-25",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-24",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-23",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-22",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-21",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-20",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-19",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-18",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-17",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-16",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-15",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-14",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-13",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-12",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-11",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-10",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-09",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-08",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-07",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-06",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-05",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-04",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-03",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-02",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-01",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      }
+    ],
+    "last_month_summary": {
+      "overall": {
+        "stat": {
+          "totalDays": 0,
+          "averageTime": 0
+        },
+        "dailyStats": [
+          {
+            "date": "2026-06-01",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-02",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-03",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-04",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-05",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-06",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-07",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-08",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-09",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-10",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-11",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-12",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-13",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-14",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-15",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-16",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-17",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-18",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-19",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-20",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-21",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-22",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-23",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-24",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-25",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-26",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-27",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-28",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-29",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-30",
+            "totalTime": 0,
+            "games": {}
+          }
+        ],
+        "ranking": [],
+        "chat": {
+          "players": []
+        }
+      },
+      "players": [
+        {
+          "profile": {
+            "playerId": "player-7",
+            "nickname": "Player 1",
+            "imageUri": "https://example.invalid/avatar.jpg",
+            "nsaId": null
+          },
+          "summary": {
+            "stat": {
+              "totalDays": 0,
+              "averageTime": 0
+            },
+            "dailyStats": [
+              {
+                "date": "2026-06-01",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-02",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-03",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-04",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-05",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-06",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-07",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-08",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-09",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-10",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-11",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-12",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-13",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-14",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-15",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-16",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-17",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-18",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-19",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-20",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-21",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-22",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-23",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-24",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-25",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-26",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-27",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-28",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-29",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-30",
+                "totalTime": 0,
+                "games": {}
+              }
+            ],
+            "ranking": [],
+            "chat": {
+              "members": []
+            }
+          }
+        }
+      ]
+    }
+  },
+  "Device 3 (P00)": {
+    "name": "Device 3",
+    "model": "Switch",
+    "generation": "P00",
+    "daily_summaries": [
+      {
+        "date": "2026-07-29",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-28",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-27",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-26",
+        "result": "UNACHIEVED",
+        "playingTime": 75,
+        "exceededTime": 75,
+        "disabledTime": 0,
+        "miscTime": 5,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {
+          "addedExtraPlayingTime": true
+        },
+        "featuredGameIconURL": {
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-8",
+              "nickname": "Player 2",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": null
+            },
+            "playingTime": 65,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 65
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-25",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-24",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-23",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-22",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-21",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-20",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-19",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-18",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-17",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-16",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-15",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-14",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-13",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-12",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-11",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-10",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-09",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-08",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-07",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-06",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-05",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-04",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-03",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-02",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-01",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-06-30",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-06-29",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      }
+    ],
+    "last_month_summary": {
+      "overall": {
+        "stat": {
+          "totalDays": 0,
+          "averageTime": 0
+        },
+        "dailyStats": [
+          {
+            "date": "2026-06-01",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-02",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-03",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-04",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-05",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-06",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-07",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-08",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-09",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-10",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-11",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-12",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-13",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-14",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-15",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-16",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-17",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-18",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-19",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-20",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-21",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-22",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-23",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-24",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-25",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-26",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-27",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-28",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-29",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-30",
+            "totalTime": 0,
+            "games": {}
+          }
+        ],
+        "ranking": [],
+        "chat": {
+          "players": []
+        }
+      },
+      "players": [
+        {
+          "profile": {
+            "playerId": "player-8",
+            "nickname": "Player 2",
+            "imageUri": "https://example.invalid/avatar.jpg",
+            "nsaId": null
+          },
+          "summary": {
+            "stat": {
+              "totalDays": 0,
+              "averageTime": 0
+            },
+            "dailyStats": [
+              {
+                "date": "2026-06-01",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-02",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-03",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-04",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-05",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-06",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-07",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-08",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-09",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-10",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-11",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-12",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-13",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-14",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-15",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-16",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-17",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-18",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-19",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-20",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-21",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-22",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-23",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-24",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-25",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-26",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-27",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-28",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-29",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-30",
+                "totalTime": 0,
+                "games": {}
+              }
+            ],
+            "ranking": [],
+            "chat": {
+              "members": []
+            }
+          }
+        }
+      ]
+    }
+  },
+  "Device 4 (P00)": {
+    "name": "Device 4",
+    "model": "Switch",
+    "generation": "P00",
+    "daily_summaries": [
+      {
+        "date": "2026-07-26",
+        "result": "CALCULATING",
+        "playingTime": 65,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 3,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {
+          "addedExtraPlayingTime": true
+        },
+        "featuredGameIconURL": {
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024"
+        },
+        "nonFeaturedGameCount": 1,
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-9",
+              "nickname": "Player 3",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": null
+            },
+            "playingTime": 65,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "0100D71004694000",
+                  "title": "Minecraft for Nintendo Switch",
+                  "imageUri": {
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_512",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_3",
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_128",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_256",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/266ea5ace7ac458baf96636332dc7c5c_1024"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/0100d71004694000/DE?lang=de-DE"
+                },
+                "playingTime": 30
+              },
+              {
+                "meta": {
+                  "applicationId": "01004FF021942000",
+                  "title": "EA SPORTS FC 26",
+                  "imageUri": {
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/54d07ce12da440b598e0e380611fba8a_512",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/54d07ce12da440b598e0e380611fba8a_3",
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/54d07ce12da440b598e0e380611fba8a_128",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/54d07ce12da440b598e0e380611fba8a_256",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/54d07ce12da440b598e0e380611fba8a_1024"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/01004ff021942000/DE?lang=de-DE"
+                },
+                "playingTime": 30
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-25",
+        "result": "ACHIEVED",
+        "playingTime": 1,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 1,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-24",
+        "result": "UNACHIEVED",
+        "playingTime": 40,
+        "exceededTime": 10,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_512",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_3",
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_128",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_256",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_1024"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-9",
+              "nickname": "Player 3",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": null
+            },
+            "playingTime": 40,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "010054E01D878000",
+                  "title": "EA SPORTS FC 25",
+                  "imageUri": {
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_512",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_3",
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_128",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_256",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_1024"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/010054e01d878000/DE?lang=de-DE"
+                },
+                "playingTime": 40
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-23",
+        "result": "UNACHIEVED",
+        "playingTime": 50,
+        "exceededTime": 20,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {
+          "addedExtraPlayingTime": true
+        },
+        "featuredGameIconURL": {
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_512",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_3",
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_128",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_256",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_1024"
+        },
+        "nonFeaturedGameCount": 1,
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-9",
+              "nickname": "Player 3",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": null
+            },
+            "playingTime": 50,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "010054E01D878000",
+                  "title": "EA SPORTS FC 25",
+                  "imageUri": {
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_512",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_3",
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_128",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_256",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_1024"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/010054e01d878000/DE?lang=de-DE"
+                },
+                "playingTime": 30
+              },
+              {
+                "meta": {
+                  "applicationId": "01003C1022148000",
+                  "title": "Electronics Supermarket Simulator",
+                  "imageUri": {
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/b15262226e754b9f87553d6945c3e608_512",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/b15262226e754b9f87553d6945c3e608_3",
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/b15262226e754b9f87553d6945c3e608_128",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/b15262226e754b9f87553d6945c3e608_256",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/b15262226e754b9f87553d6945c3e608_1024"
+                  },
+                  "hasUgc": false,
+                  "shopUri": "https://ec.nintendo.com/apps/01003c1022148000/DE?lang=de-DE"
+                },
+                "playingTime": 20
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-22",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-21",
+        "result": "UNACHIEVED",
+        "playingTime": 50,
+        "exceededTime": 20,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {
+          "addedExtraPlayingTime": true
+        },
+        "featuredGameIconURL": {
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_512",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_3",
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_128",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_256",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_1024"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-9",
+              "nickname": "Player 3",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": null
+            },
+            "playingTime": 50,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "010054E01D878000",
+                  "title": "EA SPORTS FC 25",
+                  "imageUri": {
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_512",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_3",
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_128",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_256",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_1024"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/010054e01d878000/DE?lang=de-DE"
+                },
+                "playingTime": 50
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-20",
+        "result": "UNACHIEVED",
+        "playingTime": 50,
+        "exceededTime": 20,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {
+          "addedExtraPlayingTime": true
+        },
+        "featuredGameIconURL": {
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_512",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_3",
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_128",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_256",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_1024"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-9",
+              "nickname": "Player 3",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": null
+            },
+            "playingTime": 45,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "010054E01D878000",
+                  "title": "EA SPORTS FC 25",
+                  "imageUri": {
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_512",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_3",
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_128",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_256",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_1024"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/010054e01d878000/DE?lang=de-DE"
+                },
+                "playingTime": 45
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      },
+      {
+        "date": "2026-07-19",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-18",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-17",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-16",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-15",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-14",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-13",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-12",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-11",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-10",
+        "result": "CALCULATING",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 0,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-09",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-08",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-07",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-06",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-05",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-04",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-03",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-02",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-07-01",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-06-30",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-06-29",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-06-28",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-06-27",
+        "result": "ACHIEVED",
+        "playingTime": 0,
+        "exceededTime": 0,
+        "disabledTime": 0,
+        "miscTime": 0,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "nonFeaturedGameCount": -1,
+        "players": []
+      },
+      {
+        "date": "2026-06-26",
+        "result": "UNACHIEVED",
+        "playingTime": 35,
+        "exceededTime": 5,
+        "disabledTime": 0,
+        "miscTime": 1,
+        "timeZoneUtcOffsetSeconds": 7200,
+        "events": {},
+        "featuredGameIconURL": {
+          "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_512",
+          "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_3",
+          "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_128",
+          "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_256",
+          "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_1024"
+        },
+        "players": [
+          {
+            "profile": {
+              "playerId": "player-9",
+              "nickname": "Player 3",
+              "imageUri": "https://example.invalid/avatar.jpg",
+              "nsaId": null
+            },
+            "playingTime": 30,
+            "playedGames": [
+              {
+                "meta": {
+                  "applicationId": "010054E01D878000",
+                  "title": "EA SPORTS FC 25",
+                  "imageUri": {
+                    "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_512",
+                    "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_3",
+                    "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_128",
+                    "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_256",
+                    "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_1024"
+                  },
+                  "hasUgc": true,
+                  "shopUri": "https://ec.nintendo.com/apps/010054e01d878000/DE?lang=de-DE"
+                },
+                "playingTime": 30
+              }
+            ],
+            "firstChattedFriendshipIds": [],
+            "chatHistory": []
+          }
+        ]
+      }
+    ],
+    "last_month_summary": {
+      "overall": {
+        "stat": {
+          "totalDays": 3,
+          "averageTime": 20
+        },
+        "dailyStats": [
+          {
+            "date": "2026-06-01",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-02",
+            "totalTime": 15,
+            "games": {
+              "010054E01D878000": {
+                "totalTime": 15
+              }
+            }
+          },
+          {
+            "date": "2026-06-03",
+            "totalTime": 15,
+            "games": {
+              "010054E01D878000": {
+                "totalTime": 15
+              }
+            }
+          },
+          {
+            "date": "2026-06-04",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-05",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-06",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-07",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-08",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-09",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-10",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-11",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-12",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-13",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-14",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-15",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-16",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-17",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-18",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-19",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-20",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-21",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-22",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-23",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-24",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-25",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-26",
+            "totalTime": 35,
+            "games": {
+              "010054E01D878000": {
+                "totalTime": 35
+              }
+            }
+          },
+          {
+            "date": "2026-06-27",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-28",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-29",
+            "totalTime": 0,
+            "games": {}
+          },
+          {
+            "date": "2026-06-30",
+            "totalTime": 0,
+            "games": {}
+          }
+        ],
+        "ranking": [
+          {
+            "position": "STAY",
+            "stat": {
+              "totalDays": 3,
+              "meta": {
+                "applicationId": "010054E01D878000",
+                "title": "EA SPORTS FC 25",
+                "imageUri": {
+                  "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_3",
+                  "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_512",
+                  "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_1024",
+                  "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_128",
+                  "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_256"
+                },
+                "hasUgc": true,
+                "shopUri": "https://ec.nintendo.com/apps/010054e01d878000/DE?lang=de-DE"
+              },
+              "players": [
+                {
+                  "playerId": "player-9",
+                  "nickname": "Player 3",
+                  "imageUri": "https://example.invalid/avatar.jpg",
+                  "nsaId": null
+                }
+              ]
+            }
+          }
+        ],
+        "chat": {
+          "players": []
+        }
+      },
+      "players": [
+        {
+          "profile": {
+            "playerId": "player-9",
+            "nickname": "Player 3",
+            "imageUri": "https://example.invalid/avatar.jpg",
+            "nsaId": null
+          },
+          "summary": {
+            "stat": {
+              "totalDays": 3,
+              "averageTime": 20
+            },
+            "dailyStats": [
+              {
+                "date": "2026-06-01",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-02",
+                "totalTime": 15,
+                "games": {
+                  "010054E01D878000": {
+                    "totalTime": 15
+                  }
+                }
+              },
+              {
+                "date": "2026-06-03",
+                "totalTime": 15,
+                "games": {
+                  "010054E01D878000": {
+                    "totalTime": 15
+                  }
+                }
+              },
+              {
+                "date": "2026-06-04",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-05",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-06",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-07",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-08",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-09",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-10",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-11",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-12",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-13",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-14",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-15",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-16",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-17",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-18",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-19",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-20",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-21",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-22",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-23",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-24",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-25",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-26",
+                "totalTime": 30,
+                "games": {
+                  "010054E01D878000": {
+                    "totalTime": 30
+                  }
+                }
+              },
+              {
+                "date": "2026-06-27",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-28",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-29",
+                "totalTime": 0,
+                "games": {}
+              },
+              {
+                "date": "2026-06-30",
+                "totalTime": 0,
+                "games": {}
+              }
+            ],
+            "ranking": [
+              {
+                "position": "STAY",
+                "stat": {
+                  "totalDays": 3,
+                  "meta": {
+                    "applicationId": "010054E01D878000",
+                    "title": "EA SPORTS FC 25",
+                    "imageUri": {
+                      "extraSmall": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_3",
+                      "large": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_512",
+                      "extraLarge": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_1024",
+                      "small": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_128",
+                      "medium": "https://atum-img-lp1.cdn.nintendo.net/i/c/22a54201c85a47af8743b3f7e140720b_256"
+                    },
+                    "hasUgc": true,
+                    "shopUri": "https://ec.nintendo.com/apps/010054e01d878000/DE?lang=de-DE"
+                  },
+                  "players": [
+                    {
+                      "playerId": "player-9",
+                      "nickname": "Player 3",
+                      "imageUri": "https://example.invalid/avatar.jpg",
+                      "nsaId": null
+                    }
+                  ]
+                }
+              }
+            ],
+            "chat": {
+              "members": []
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 import aiofiles
 
+from pynintendoparental.application import ApplicationRegistry
 from pynintendoparental.device import Device
+from pynintendoparental.player import PlayerRegistry
 
 
 async def load_fixture(filename: str) -> dict:
@@ -26,7 +28,11 @@ def clean_device_for_snapshot(device: Device) -> dict:
     for key, value in device.__dict__.items():
         if key.startswith("_"):
             continue
-        if isinstance(value, list):
+        if isinstance(value, ApplicationRegistry):
+            cleaned[key] = {app.application_id: app for app in value}
+        elif isinstance(value, PlayerRegistry):
+            cleaned[key] = {player.player_id: player for player in value}
+        elif isinstance(value, list):
             cleaned[key] = [clean_device_for_snapshot(v) if hasattr(v, "__dict__") else v for v in value]
         elif hasattr(value, "__dict__"):
             cleaned[key] = clean_device_for_snapshot(value)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,14 +4,18 @@ from __future__ import annotations
 
 import copy
 import json
-from datetime import time
+from datetime import datetime, time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import aiofiles
 
 from pynintendoparental.application import ApplicationRegistry
 from pynintendoparental.device import Device
 from pynintendoparental.player import PlayerRegistry
+
+if TYPE_CHECKING:
+    from pynintendoparental.api import Api
 
 
 async def load_fixture(filename: str) -> dict:
@@ -116,3 +120,92 @@ def daily_summaries_for(summaries: dict, date: str, playing_time: int) -> dict:
     result["dailySummaries"][0]["date"] = date
     result["dailySummaries"][0]["playingTime"] = playing_time
     return result
+
+
+def unique_played_games(daily_summaries: list[dict]) -> list[dict]:
+    """Return unique whitelist-shaped entries from daily-summary playedGames meta."""
+    seen: dict[str, dict] = {}
+    for summary in daily_summaries:
+        for player in summary.get("players", []):
+            for game in player.get("playedGames") or []:
+                meta = game.get("meta") or {}
+                app_id = meta.get("applicationId")
+                if not app_id or app_id in seen:
+                    continue
+                image = meta.get("imageUri")
+                if isinstance(image, dict):
+                    image = image.get("small")
+                seen[app_id] = {
+                    "applicationId": app_id,
+                    "title": meta.get("title"),
+                    "imageUri": image,
+                    "safeLaunch": "NONE",
+                }
+    return list(seen.values())
+
+
+def pcs_with_dump_whitelist(pcs: dict, daily_summaries: list[dict]) -> dict:
+    """Return a deep-copied PCS whose whitelist is the dump's played games."""
+    result = copy.deepcopy(pcs)
+    result["parentalControlSetting"]["whitelistedApplicationList"] = unique_played_games(daily_summaries)
+    return result
+
+
+def daily_summary_on(entry: dict, date: str) -> dict:
+    """Return the daily summary for a dump entry date."""
+    for summary in entry["daily_summaries"]:
+        if summary["date"] == date:
+            return summary
+    raise KeyError(f"No daily summary for {date}")
+
+
+def _dump_device_id(entry: dict) -> str:
+    """Synthetic device id for a dump entry that has none."""
+    return f"dump-{entry['name'].replace(' ', '-').lower()}"
+
+
+def configure_mock_api_for_dump(
+    mock_api: Api,
+    entry: dict,
+    pcs: dict,
+    account_device: dict,
+) -> None:
+    """Wire API mocks so Device.update() consumes a multiple-devices dump entry."""
+    extra = copy.deepcopy(account_device)
+    extra["ownedDevice"]["device"]["platformGeneration"] = entry["generation"]
+    first_month_date = entry["last_month_summary"]["overall"]["dailyStats"][0]["date"]
+    year, month, _day = first_month_date.split("-")
+
+    mock_api.async_get_device_daily_summaries.return_value = {"json": {"dailySummaries": entry["daily_summaries"]}}
+    mock_api.async_get_device_monthly_summaries.return_value = {
+        "json": {"available": [{"year": int(year), "month": int(month)}]}
+    }
+    mock_api.async_get_device_monthly_summary.return_value = {"json": {"summary": entry["last_month_summary"]}}
+    mock_api.async_get_device_parental_control_setting.return_value = {"json": pcs}
+    mock_api.async_get_account_device.return_value = {"json": extra}
+
+
+async def device_from_dump(
+    entry: dict,
+    mock_api: Api,
+    pcs: dict,
+    account_device: dict | None = None,
+) -> Device:
+    """Build a Device from a multiple-devices dump entry and run update()."""
+    if account_device is None:
+        account_device = await load_fixture("account_device")
+    dump_pcs = pcs_with_dump_whitelist(pcs, entry["daily_summaries"])
+    configure_mock_api_for_dump(mock_api, entry, dump_pcs, account_device)
+    raw = {
+        "deviceId": _dump_device_id(entry),
+        "label": entry["name"],
+        "parentalControlSettingState": {"updatedAt": 0},
+        "platformGeneration": entry["generation"],
+        "alarmSetting": {"visibility": "VISIBLE"},
+    }
+    device = Device.from_device_response(raw, mock_api)
+    first_date = datetime.strptime(entry["daily_summaries"][0]["date"], "%Y-%m-%d").replace(
+        hour=12, minute=0, second=0, microsecond=0
+    )
+    await device.update(now=first_date)
+    return device

--- a/tests/snapshots/test_device.ambr
+++ b/tests/snapshots/test_device.ambr
@@ -4274,22 +4274,20 @@
       ),
       'B276150DE6B18218C09E4D0CE4CFA0861A3': Player(
         apps=list([
-          dict({
-            'meta': dict({
-              'applicationId': '0100152000022000',
-              'hasUgc': False,
-              'imageUri': dict({
-                'extraLarge': 'https://atum-img-lp1.cdn.nintendo.net/i/c/fd75c85d0465407cba8249e93c21e831_1024',
-                'extraSmall': 'https://atum-img-lp1.cdn.nintendo.net/i/c/fd75c85d0465407cba8249e93c21e831_3',
-                'large': 'https://atum-img-lp1.cdn.nintendo.net/i/c/fd75c85d0465407cba8249e93c21e831_512',
-                'medium': 'https://atum-img-lp1.cdn.nintendo.net/i/c/fd75c85d0465407cba8249e93c21e831_256',
-                'small': 'https://atum-img-lp1.cdn.nintendo.net/i/c/fd75c85d0465407cba8249e93c21e831_128',
-              }),
-              'shopUri': 'https://ec.nintendo.com/apps/0100152000022000/GB?lang=en-GB',
-              'title': 'five',
-            }),
-            'playingTime': 15,
-          }),
+          PlayedAppUsage(
+            application=Application(
+              application_id='0100152000022000',
+              first_played_date=None,
+              has_ugc=None,
+              image_url='https://picsum.photos/237/540',
+              name='five',
+              playing_days=None,
+              safe_launch_setting=<SafeLaunchSetting.ALLOW: 'ALLOW'>,
+              shop_url=None,
+              today_time_played=15,
+            ),
+            playing_time=15,
+          ),
         ]),
         month_summary=dict({
           'chat': dict({
@@ -5148,7 +5146,5 @@
     'today_observations': list([
     ]),
     'today_playing_time': 60,
-    'whitelisted_applications': dict({
-    }),
   })
 # ---

--- a/tests/snapshots/test_player.ambr
+++ b/tests/snapshots/test_player.ambr
@@ -2,22 +2,20 @@
 # name: test_player_parsing
   Player(
     apps=list([
-      dict({
-        'meta': dict({
-          'applicationId': '0100152000022000',
-          'hasUgc': False,
-          'imageUri': dict({
-            'extraLarge': 'https://atum-img-lp1.cdn.nintendo.net/i/c/fd75c85d0465407cba8249e93c21e831_1024',
-            'extraSmall': 'https://atum-img-lp1.cdn.nintendo.net/i/c/fd75c85d0465407cba8249e93c21e831_3',
-            'large': 'https://atum-img-lp1.cdn.nintendo.net/i/c/fd75c85d0465407cba8249e93c21e831_512',
-            'medium': 'https://atum-img-lp1.cdn.nintendo.net/i/c/fd75c85d0465407cba8249e93c21e831_256',
-            'small': 'https://atum-img-lp1.cdn.nintendo.net/i/c/fd75c85d0465407cba8249e93c21e831_128',
-          }),
-          'shopUri': 'https://ec.nintendo.com/apps/0100152000022000/GB?lang=en-GB',
-          'title': 'five',
-        }),
-        'playingTime': 15,
-      }),
+      PlayedAppUsage(
+        application=Application(
+          application_id='0100152000022000',
+          first_played_date=None,
+          has_ugc=None,
+          image_url='https://picsum.photos/237/540',
+          name='five',
+          playing_days=None,
+          safe_launch_setting=<SafeLaunchSetting.ALLOW: 'ALLOW'>,
+          shop_url=None,
+          today_time_played=15,
+        ),
+        playing_time=15,
+      ),
     ]),
     month_summary=dict({
     }),
@@ -30,9 +28,20 @@
 # name: test_player_update_from_daily_summary
   Player(
     apps=list([
-      dict({
-        'app': 'new_app',
-      }),
+      PlayedAppUsage(
+        application=Application(
+          application_id='010042D00D900000',
+          first_played_date=None,
+          has_ugc=None,
+          image_url='https://picsum.photos/124/516',
+          name='government',
+          playing_days=None,
+          safe_launch_setting=<SafeLaunchSetting.ALLOW: 'ALLOW'>,
+          shop_url=None,
+          today_time_played=0,
+        ),
+        playing_time=100,
+      ),
     ]),
     month_summary=dict({
     }),

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -1,5 +1,6 @@
 """Unit tests for the Application class."""
 
+import copy
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
@@ -19,7 +20,7 @@ async def test_application_callback(mock_api: Api):
     assert len(devices) > 0
     device = devices[0]
     assert len(device.applications) > 0
-    app = list(device.applications.values())[0]
+    app = device.applications.get_application("0100152000022000")
 
     sync_callback = Mock()
     async_callback = AsyncMock()
@@ -122,16 +123,24 @@ async def test_application_set_safe_launch_setting(mock_api: Api, setting: SafeL
     device = devices[0]
     assert len(device.applications) > 0
 
-    # Select the first application
-    application = list(device.applications.values())[0]
-    # Update pcs_response
-    pcs_response["json"]["parentalControlSetting"]["whitelistedApplicationList"][0]["safeLaunch"] = str(setting)
+    application = device.applications.get_application("0100152000022000")
+    expected_pcs = copy.deepcopy(application._parental_control_settings)
+    for app in expected_pcs["whitelistedApplicationList"]:
+        if app["applicationId"].upper() == application.application_id.upper():
+            app["safeLaunch"] = str(setting)
+            break
+    else:
+        pytest.fail(f"Application {application.application_id} not in whitelist")
+
+    # Mock response must update the same app so the post-call callback applies it.
+    for app in pcs_response["json"]["parentalControlSetting"]["whitelistedApplicationList"]:
+        if app["applicationId"].upper() == application.application_id.upper():
+            app["safeLaunch"] = str(setting)
+            break
     mock_api.async_update_restriction_level.return_value = pcs_response
     await application.set_safe_launch_setting(setting)
 
-    mock_api.async_update_restriction_level.assert_called_with(
-        device.device_id, pcs_response["json"]["parentalControlSetting"]
-    )
+    mock_api.async_update_restriction_level.assert_called_with(device.device_id, expected_pcs)
     assert application.safe_launch_setting is setting
 
 
@@ -183,20 +192,17 @@ async def test_application_set_safe_launch_setting_whitelist_errors(
 ):
     """Test the application set_safe_launch_setting correctly errors for whitelist problems."""
     devices_response = await load_fixture("account_devices")
-    pcs_response = {"json": await load_fixture("device_parental_control_setting")}
     devices = await Device.from_devices_response(devices_response, mock_api)
     assert len(devices) > 0
     device = devices[0]
     assert len(device.applications) > 0
 
-    # Select the first application
-    application = list(device.applications.values())[0]
-    # Update pcs_response
-    pcs_response["json"]["parentalControlSetting"]["whitelistedApplicationList"][0]["safeLaunch"] = str(setting)
-    # Override application pcs
-    application._parental_control_settings["whitelistedApplicationList"] = application._parental_control_settings[
-        "whitelistedApplicationList"
-    ][1:-1]
+    application = device.applications.get_application("0100152000022000")
+    application._parental_control_settings["whitelistedApplicationList"] = [
+        app
+        for app in application._parental_control_settings["whitelistedApplicationList"]
+        if app["applicationId"].upper() != application.application_id.upper()
+    ]
     with pytest.raises(exception):
         await application.set_safe_launch_setting(setting)
 

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -207,3 +207,149 @@ async def test_application_set_safe_launch_setting_whitelist_errors(
         await application.set_safe_launch_setting(setting)
 
     mock_api.async_update_restriction_level.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "val1,val2,expected",
+    [
+        pytest.param(
+            
+            Application(
+                app_id="TESTAPPID",
+                name="TESTAPPNAME",
+                device_id="TESTDEVICEID",
+                api=AsyncMock(),
+                send_api_update=None,
+                callbacks=[],
+            ),
+            Application(
+                app_id="TESTAPPID",
+                name="TESTAPPNAME",
+                device_id="TESTDEVICEID",
+                api=AsyncMock(),
+                send_api_update=None,
+                callbacks=[],
+            ),
+            True,
+        ),
+        pytest.param(
+            Application(
+                app_id="TESTAPPID1",
+                name="TESTAPPNAME",
+                device_id="TESTDEVICEID",
+                api=AsyncMock(),
+                send_api_update=None,
+                callbacks=[],
+            ),
+            Application(
+                app_id="TESTAPPID2",
+                name="TESTAPPNAME",
+                device_id="TESTDEVICEID",
+                api=AsyncMock(),
+                send_api_update=None,
+                callbacks=[],
+            ),
+            False,
+        ),
+        pytest.param(
+            Application(
+                app_id="TESTAPPID",
+                name="TESTAPPNAME1",
+                device_id="TESTDEVICEID",
+                api=AsyncMock(),
+                send_api_update=None,
+                callbacks=[],
+            ),
+            "TESTAPPNAME1",
+            False,
+        ),
+    ]
+)
+async def test_application_class_equality(
+    val1: Application, val2: Application, expected: bool
+):
+    """Test the equality operator for the Application class."""
+    assert (val1 == val2) is expected
+
+
+@pytest.mark.parametrize(
+    "name,is_exception,expected_result",
+    [
+        pytest.param("five", False, "0100152000022000"),
+        pytest.param("Nonexistent Game", True, ValueError),
+    ]
+)
+async def test_application_registry_get_name(
+    name: str, is_exception: bool, expected_result, mock_api: Api
+):
+    """Test the ApplicationRegistry.get_name method."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    assert len(devices) > 0
+    device = devices[0]
+    assert len(device.applications) > 0
+
+    if is_exception:
+        with pytest.raises(expected_result) as exc_info:
+            device.applications.get_application_by_name(name)
+        assert "Application Nonexistent Game not found." in str(exc_info.value)
+    else:
+        result = device.applications.get_application_by_name(name)
+        assert result.application_id == expected_result
+
+
+async def test_application_registry_add_exception(
+    mock_api: Api
+):
+    """Test the ApplicationRegistry.add method."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    assert len(devices) > 0
+    device = devices[0]
+    assert len(device.applications) > 0
+
+    with pytest.raises(ValueError) as exc_info:
+        device.applications.add_application(
+            Application(
+                app_id="0100152000022000",
+                name="five",
+                device_id="TESTDEVICEID",
+                api=AsyncMock(),
+                send_api_update=None,
+                callbacks=[],
+            )
+        )
+    assert "Application 0100152000022000 already in registry." in str(exc_info.value)
+
+
+async def test_application_registry_remove_exception(
+    mock_api: Api
+):
+    """Test the ApplicationRegistry.remove method."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    assert len(devices) > 0
+    device = devices[0]
+    assert len(device.applications) > 0
+
+    with pytest.raises(ValueError) as exc_info:
+        device.applications.remove_application("INVALID_APP_ID")
+    assert "Application INVALID_APP_ID not found." in str(exc_info.value)
+
+
+async def test_application_registry_remove(
+    mock_api: Api
+):
+    """Test the ApplicationRegistry.remove method."""
+    devices_response = await load_fixture("account_devices")
+    devices = await Device.from_devices_response(devices_response, mock_api)
+    assert len(devices) > 0
+    device = devices[0]
+    assert len(device.applications) > 0
+
+    app_id_to_remove = "0100152000022000"
+    device.applications.remove_application(app_id_to_remove)
+
+    with pytest.raises(ValueError) as exc_info:
+        device.applications.get_application(app_id_to_remove)
+    assert f"Application {app_id_to_remove} not found." in str(exc_info.value)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -76,7 +76,7 @@ async def test_player_discovery(device: Device, mock_api: Api):
 
 async def test_get_player(device: Device):
     """Test that the get_player method works as expected."""
-    first_player_id = list(device.players.keys())[0]
+    first_player_id = next(iter(device.players)).player_id
     player = device.get_player(first_player_id)
     assert player.player_id == first_player_id
 
@@ -86,7 +86,7 @@ async def test_get_player(device: Device):
 
 async def test_get_application(device: Device):
     """Test that the get_application method works as expected."""
-    first_app_id = list(device.applications.keys())[0]
+    first_app_id = next(iter(device.applications)).application_id
     application = device.get_application(first_app_id)
     assert application.application_id == first_app_id
 
@@ -451,10 +451,10 @@ async def test_device_callbacks(device: Device):
     sync_callback.assert_not_called()
     async_callback.assert_not_called()
 
-    with pytest.raises(ValueError, match="Object must be callable."):
+    with pytest.raises(TypeError, match="Object must be callable."):
         device.remove_device_callback("not a function")
 
-    with pytest.raises(ValueError, match="Object must be callable."):
+    with pytest.raises(TypeError, match="Object must be callable."):
         device.add_device_callback("not a function")
 
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -2,7 +2,7 @@
 
 import copy
 import logging
-from datetime import datetime, time
+from datetime import datetime, time, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -780,6 +780,20 @@ async def test_bedtime_rollover(device: Device, hour: int, expected_remaining: i
     device._calculate_today_remaining_time(now)  # pylint: disable=protected-access
 
     assert device.today_time_remaining == expected_remaining
+
+
+async def test_bedtime_rollover_with_timezone_aware_now(device: Device):
+    """Bedtime calculations work when the current time is timezone-aware."""
+    device.bedtime_alarm = time(hour=0, minute=15)
+    device.alarms_enabled = True
+    device.limit_time = 480
+    device.today_playing_time = 0
+
+    now = FIXED_NOW.replace(hour=23, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+    device._calculate_today_remaining_time(now)  # pylint: disable=protected-access
+
+    assert device.today_time_remaining == 75
+    assert device.stats_update_failed is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_multiple_devices.py
+++ b/tests/test_multiple_devices.py
@@ -1,0 +1,181 @@
+"""Tests that parse the multi-device dump into Device / Player / Application dataclasses."""
+
+import pytest
+
+from pynintendoparental.api import Api
+from pynintendoparental.application import Application, PlayedAppUsage
+from pynintendoparental.device import Device
+from pynintendoparental.player import Player
+
+from .helpers import (
+    daily_summary_on,
+    device_from_dump,
+    load_fixture,
+    unique_played_games,
+)
+
+DUMP_KEYS = (
+    "Device 1 (P01)",
+    "Device 2 (P00)",
+    "Device 3 (P00)",
+    "Device 4 (P00)",
+)
+
+MINECRAFT_ID = "0100D71004694000"
+FC26_ID = "01004FF021942000"
+
+
+@pytest.fixture
+async def dump() -> dict:
+    """The anonymised four-device dump."""
+    return await load_fixture("multiple_devices")
+
+
+async def _load_device(dump: dict, dump_key: str, mock_api: Api, pcs: dict) -> tuple[dict, Device]:
+    """Load one dump entry into a Device via mocked API responses."""
+    entry = dump[dump_key]
+    device = await device_from_dump(entry, mock_api, pcs)
+    return entry, device
+
+
+def _monthly_profiles(entry: dict) -> list[dict]:
+    """Return monthly-summary player profiles that include a playerId."""
+    profiles = []
+    for player in entry["last_month_summary"].get("players", []):
+        profile = player.get("profile") or {}
+        if profile.get("playerId"):
+            profiles.append(profile)
+    return profiles
+
+
+@pytest.mark.parametrize("dump_key", DUMP_KEYS)
+async def test_dump_device_parsing(dump_key: str, dump: dict, mock_api: Api, pcs: dict):
+    """Each dump device loads into Device, Player, and Application dataclasses."""
+    entry, device = await _load_device(dump, dump_key, mock_api, pcs)
+    today = entry["daily_summaries"][0]
+
+    assert isinstance(device, Device)
+    assert device.name == entry["name"]
+    assert device.generation == entry["generation"]
+    assert device.model == entry["model"]
+    assert device.daily_summaries == entry["daily_summaries"]
+    assert device.last_month_summary == entry["last_month_summary"]
+    assert device.today_playing_time == (today.get("playingTime") or 0)
+    assert device.today_exceeded_time == (today.get("exceededTime") or 0)
+
+    for profile in _monthly_profiles(entry):
+        player = device.get_player(profile["playerId"])
+        assert isinstance(player, Player)
+        assert player.player_id == profile["playerId"]
+        assert player.nickname == profile["nickname"]
+        assert player.month_summary == next(
+            p["summary"]
+            for p in entry["last_month_summary"]["players"]
+            if p.get("profile", {}).get("playerId") == profile["playerId"]
+        )
+
+    for game in unique_played_games(entry["daily_summaries"]):
+        application = device.get_application(game["applicationId"])
+        assert isinstance(application, Application)
+        assert application.application_id == game["applicationId"]
+        assert application.name == game["title"]
+
+
+async def test_calculating_empty_today(dump: dict, mock_api: Api, pcs: dict):
+    """Device 1 today is CALCULATING with no players; monthly players keep empty apps."""
+    entry, device = await _load_device(dump, "Device 1 (P01)", mock_api, pcs)
+    today = entry["daily_summaries"][0]
+
+    assert today["date"] == "2026-08-17"
+    assert today["result"] == "CALCULATING"
+    assert today["players"] == []
+    assert device.today_playing_time == 0
+    assert _monthly_profiles(entry)
+    for player in device.players:
+        assert isinstance(player, Player)
+        assert player.apps == []
+
+
+async def test_shared_play_same_game_same_time(dump: dict, mock_api: Api, pcs: dict):
+    """Device 1 on 2026-08-16: two players, each Minecraft 70 against a device total of 70."""
+    entry, device = await _load_device(dump, "Device 1 (P01)", mock_api, pcs)
+    day = daily_summary_on(entry, "2026-08-16")
+    players = Player.from_device_daily_summary([day], device.applications)
+
+    assert day["playingTime"] == 70
+    assert len(players) == 2
+    for player in players:
+        assert isinstance(player, Player)
+        assert player.playing_time == 70
+        assert len(player.apps) == 1
+        usage = player.apps[0]
+        assert isinstance(usage, PlayedAppUsage)
+        assert usage.playing_time == 70
+        assert usage.application.application_id == MINECRAFT_ID
+        assert usage.application is device.get_application(MINECRAFT_ID)
+
+
+async def test_uneven_shared_play_cumulative_application_time(dump: dict, mock_api: Api, pcs: dict):
+    """Device 1 on 2026-08-10: Minecraft 75+15 is summed on Application.today_time_played."""
+    entry, device = await _load_device(dump, "Device 1 (P01)", mock_api, pcs)
+    day = daily_summary_on(entry, "2026-08-10")
+    players = {p.player_id: p for p in Player.from_device_daily_summary([day], device.applications)}
+
+    assert day["playingTime"] == 115
+    assert players["player-1"].playing_time == 75
+    assert players["player-1"].apps[0].playing_time == 75
+    assert players["player-1"].apps[0].application.application_id == MINECRAFT_ID
+    assert players["player-2"].playing_time == 15
+    assert players["player-2"].apps[0].playing_time == 15
+    assert players["player-2"].apps[0].application.application_id == MINECRAFT_ID
+    assert players["player-3"].playing_time == 35
+    assert players["player-3"].apps[0].playing_time == 35
+    assert players["player-3"].apps[0].application.application_id == FC26_ID
+
+    device.daily_summaries = [day]
+    minecraft = device.get_application(MINECRAFT_ID)
+    await minecraft._internal_update_callback(device)  # pylint: disable=protected-access
+    assert minecraft.today_time_played == 90
+
+
+async def test_two_games_one_player(dump: dict, mock_api: Api, pcs: dict):
+    """Device 4 today has one player with two PlayedAppUsage entries (30 + 30 vs 65)."""
+    entry, device = await _load_device(dump, "Device 4 (P00)", mock_api, pcs)
+    today = entry["daily_summaries"][0]
+    player = device.get_player("player-9")
+
+    assert today["date"] == "2026-07-26"
+    assert today["playingTime"] == 65
+    assert device.today_playing_time == 65
+    assert isinstance(player, Player)
+    assert player.playing_time == 65
+    assert len(player.apps) == 2
+    by_id = {usage.application.application_id: usage for usage in player.apps}
+    assert set(by_id) == {MINECRAFT_ID, FC26_ID}
+    assert all(isinstance(usage, PlayedAppUsage) for usage in player.apps)
+    assert by_id[MINECRAFT_ID].playing_time == 30
+    assert by_id[FC26_ID].playing_time == 30
+    assert by_id[MINECRAFT_ID].application is device.get_application(MINECRAFT_ID)
+    assert by_id[FC26_ID].application is device.get_application(FC26_ID)
+
+
+async def test_unachieved_extra_playing_time_event(dump: dict, mock_api: Api, pcs: dict):
+    """Device 2 on 2026-07-26 is UNACHIEVED with extra playing time and Minecraft 65."""
+    entry, device = await _load_device(dump, "Device 2 (P00)", mock_api, pcs)
+    day = daily_summary_on(entry, "2026-07-26")
+    players = Player.from_device_daily_summary([day], device.applications)
+
+    assert day["result"] == "UNACHIEVED"
+    assert day["exceededTime"] == 70
+    assert day["events"]["addedExtraPlayingTime"] is True
+    assert len(players) == 1
+    player = players[0]
+    assert player.player_id == "player-7"
+    assert isinstance(player, Player)
+    assert player.playing_time == 65
+    assert len(player.apps) == 1
+    usage = player.apps[0]
+    assert isinstance(usage, PlayedAppUsage)
+    assert usage.playing_time == 65
+    assert usage.application.application_id == MINECRAFT_ID
+    assert usage.application is device.get_application(MINECRAFT_ID)

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -7,7 +7,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from pynintendoparental.application import ApplicationRegistry
-from pynintendoparental.player import Player, PlayerRegistry
+from pynintendoparental.player import Player, PlayerRegistry, parse_played_apps
 
 from .helpers import load_fixture
 
@@ -98,3 +98,26 @@ async def test_player_update_from_daily_summary(
     assert player.apps[0].application.application_id == updated_app_id
     assert player.apps[0].playing_time == 100
     assert player == snapshot
+
+async def test_player_parse_played_apps_ignoring_none(
+    app_registry: ApplicationRegistry,
+):
+    """Test the parse_played_apps function ignores apps with a null application id."""
+    raw = [
+        {"applicationId": "010042D00D900000", "playingTime": 100},
+        {"applicationId": None, "playingTime": 200},
+    ]
+    apps = parse_played_apps(raw, app_registry)
+    assert len(apps) == 1
+    assert apps[0].application.application_id == "010042D00D900000"
+    assert apps[0].playing_time == 100
+
+async def test_player_registry_get(
+    player_registry: PlayerRegistry,
+):
+    """Test the player registry get method works as expected."""
+    player = Player()
+    player.player_id = "player_id"
+    player_registry.add_player(player)
+    assert player_registry.get(player.player_id) == player
+    assert player_registry.get("missing_player") is None

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,28 +1,80 @@
 """Tests for the Player class."""
 
 import copy
+import logging
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from pynintendoparental.player import Player
+from pynintendoparental.application import ApplicationRegistry
+from pynintendoparental.player import Player, PlayerRegistry
 
 from .helpers import load_fixture
 
 
-async def test_player_parsing(snapshot: SnapshotAssertion):
+async def test_player_parsing(
+    snapshot: SnapshotAssertion,
+    app_registry: ApplicationRegistry,
+):
     """Test that the player class parsing works as expected."""
     daily_summaries_response = await load_fixture("device_daily_summaries")
-    players = Player.from_device_daily_summary(daily_summaries_response["dailySummaries"])
+    players = Player.from_device_daily_summary(daily_summaries_response["dailySummaries"], app_registry)
     assert len(players) > 0
     player = players[0]
-
     assert player == snapshot
 
+async def test_player_parsing_with_missing_app(
+    caplog: pytest.LogCaptureFixture,
+    app_registry: ApplicationRegistry,
+):
+    """Test that the player class parsing works as expected when an app is missing from the registry."""
+    daily_summaries_response = await load_fixture("device_daily_summaries")
+    daily_summaries_response["dailySummaries"][0]["players"][0]["playedGames"][0]["applicationId"] = "missing_app"
+    with caplog.at_level(logging.WARNING):
+        players = Player.from_device_daily_summary(daily_summaries_response["dailySummaries"], app_registry)
+    assert "Application missing_app not found in registry, skipping." in caplog.text
+    assert len(players) == 1
+    assert players[0].apps == []
 
-async def test_player_update_from_daily_summary(snapshot: SnapshotAssertion):
+async def test_player_registry(
+    app_registry: ApplicationRegistry,
+    player_registry: PlayerRegistry,
+):
+    """Test that the player registry works as expected."""
+    daily_summaries_response = await load_fixture("device_daily_summaries")
+    players = Player.from_device_daily_summary(daily_summaries_response["dailySummaries"], app_registry)
+    assert len(players) > 0
+    player = players[0]
+    player_registry.add_player(player)
+    assert player_registry.get_player(player.player_id) == player
+    assert len(player_registry) == 1
+    player_registry.remove_player(player.player_id)
+    assert len(player_registry) == 0
+
+async def test_player_registry_exceptions(
+    player_registry: PlayerRegistry,
+):
+    """Test that the player registry exceptions work as expected."""
+    player = Player()
+    player.player_id = "player_id"
+    # Test exception
+    with pytest.raises(ValueError):
+        player_registry.remove_player(player.player_id)
+    # Test not found
+    with pytest.raises(ValueError):
+        player_registry.get_player(player.player_id)
+    # Test already in registry
+    player_registry.add_player(player)
+    with pytest.raises(ValueError):
+        player_registry.add_player(player)
+
+async def test_player_update_from_daily_summary(
+    snapshot: SnapshotAssertion,
+    app_registry: ApplicationRegistry,
+):
     """Test that updating a player from a daily summary works."""
     daily_summaries_response = await load_fixture("device_daily_summaries")
-    players = Player.from_device_daily_summary(daily_summaries_response["dailySummaries"])
+    players = Player.from_device_daily_summary(daily_summaries_response["dailySummaries"], app_registry)
     assert len(players) > 0
     player = players[0]
 
@@ -30,14 +82,19 @@ async def test_player_update_from_daily_summary(snapshot: SnapshotAssertion):
     updated_summary = copy.deepcopy(daily_summaries_response)
 
     # Find the corresponding player in the new summary and update their data
+    updated_app_id = "010042D00D900000"
     for p_summary in updated_summary["dailySummaries"][0]["players"]:
         if p_summary["profile"]["playerId"] == player.player_id:
             p_summary["playingTime"] = 54321
-            p_summary["playedGames"] = [{"app": "new_app"}]
+            p_summary["playedGames"] = [
+                {"applicationId": updated_app_id, "playingTime": 100},
+            ]
             break
 
-    player.update_from_daily_summary(updated_summary["dailySummaries"])
+    player.update_from_daily_summary(updated_summary["dailySummaries"], app_registry)
 
     assert player.playing_time == 54321
-    assert player.apps == [{"app": "new_app"}]
+    assert len(player.apps) == 1
+    assert player.apps[0].application.application_id == updated_app_id
+    assert player.apps[0].playing_time == 100
     assert player == snapshot


### PR DESCRIPTION
## Summary

- Add `ApplicationRegistry` and `PlayerRegistry` so `Device.players` and `Device.applications` are iterable collections instead of dicts.
- Parse daily-summary played games into typed `PlayedAppUsage` objects (`application` + `playing_time`) instead of leaving raw API dicts on `Player.apps`.
- Drop unused `Device.whitelisted_applications`.

## Breaking changes

Callers that treated these as dicts will need updates (Home Assistant, docs, and local tests still use the old shape):

| Before | After |
|---|---|
| `device.players.values()` / `.keys()` | iterate `device.players`; look up with `device.get_player(id)` |
| `device.applications.values()` / `.keys()` | iterate `device.applications`; look up with `device.get_application(id)` |
| `player.apps` as `list[dict]` (`applicationId`, `playingTime`) | `list[PlayedAppUsage]` with `.application` and `.playing_time` |
| `Player.from_device_daily_summary(raw)` / `update_from_daily_summary(raw)` | both now require an `ApplicationRegistry` |

`Device.get_player()` / `get_application()` still exist and now delegate to the registries.

## Test plan

- [x] Update `tests/test_player.py` — `from_device_daily_summary` / `update_from_daily_summary` signatures and `player.apps` assertions.
- [x] Update `tests/test_device.py` and `tests/test_applications.py` — replace `.keys()` / `.values()`.
- [ ] Confirm a played game that is **not** on the whitelist does not raise (today `parse_played_apps` calls `get_application()`, which raises `ValueError`).
- [x] Confirm update order: `_update_applications()` currently runs **after** `player.update_from_daily_summary()`, so the registry may still be empty on first parse.
- [x] Refresh snapshots after player parsing changes.
- [ ] Update README / `docs/guide/examples.md` (`device.players.values()`, `app['applicationId']`).
- [ ] Device docstring still says players/applications are dictionaries — align it with the registries.

`test.py` only reorders imports; it is unrelated to the feature. This will allow https://github.com/home-assistant/core/pull/173160 to move forward