### PR TITLE
Reset player daily summary stats at midnight

### DIFF
--- a/pynintendoparental/device/_core.py
+++ b/pynintendoparental/device/_core.py
@@ -138,7 +138,7 @@ class Device(
         self._update_applications()
         self._hydrate_players_from_monthly_summary(self.last_month_summary)
         for player in self.players:
-            player.update_from_daily_summary(self.daily_summaries, self.applications)
+            player.update_from_daily_summary(self.daily_summaries, self.applications, now=now)
         await self._execute_callbacks()
 
     def _update_applications(self):
@@ -146,14 +146,16 @@ class Device(
         _LOGGER.debug(">> Device._update_applications()")
         for app in self.parental_control_settings.get("whitelistedApplicationList", []):
             if app["applicationId"] not in self.applications:
-                self.applications.add_application(Application(
-                    app_id=app["applicationId"],
-                    name=app["title"],
-                    device_id=self.device_id,
-                    api=self._api,
-                    send_api_update=self._send_api_update,
-                    callbacks=self._internal_callbacks,
-                ))
+                self.applications.add_application(
+                    Application(
+                        app_id=app["applicationId"],
+                        name=app["title"],
+                        device_id=self.device_id,
+                        api=self._api,
+                        send_api_update=self._send_api_update,
+                        callbacks=self._internal_callbacks,
+                    )
+                )
 
     def _get_today_regulation(self, now: datetime) -> dict:
         """Returns the regulation settings for the current day."""

--- a/pynintendoparental/player.py
+++ b/pynintendoparental/player.py
@@ -1,5 +1,7 @@
 """Nintendo Player."""
 
+from datetime import datetime, timezone
+
 from .application import ApplicationRegistry, PlayedAppUsage
 from .const import _LOGGER
 
@@ -70,8 +72,15 @@ class Player:
             if self.player_id == player["profile"].get("playerId"):
                 self.player_image = player["profile"].get("imageUri")
                 self.nickname = player["profile"].get("nickname")
-                self.playing_time = player.get("playingTime")
-                self.apps = parse_played_apps(player.get("playedGames"), app_registry)
+                # Parse the date, to check if it is today or not (ha-core/179748)
+                if datetime.strptime(
+                    raw[0].get("date"), "%Y-%m-%d"
+                ).replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
+                    self.playing_time = 0
+                    self.apps.clear()
+                else:
+                    self.playing_time = player.get("playingTime")
+                    self.apps = parse_played_apps(player.get("playedGames"), app_registry)
                 break
 
     @classmethod
@@ -95,11 +104,14 @@ class Player:
             parsed.player_id = player["profile"].get("playerId")
             parsed.player_image = player["profile"].get("imageUri")
             parsed.nickname = player["profile"].get("nickname")
-            parsed.playing_time = player.get("playingTime")
-            parsed.apps = parse_played_apps(
-                player.get("playedGames"),
-                app_registry,
-            )
+            if datetime.strptime(
+                raw[0].get("date"), "%Y-%m-%d"
+            ).replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
+                parsed.playing_time = 0
+                parsed.apps.clear()
+            else:
+                parsed.playing_time = player.get("playingTime")
+                parsed.apps = parse_played_apps(player.get("playedGames"), app_registry)
             players.append(parsed)
             _LOGGER.debug("Built player %s", parsed.player_id)
         return players

--- a/pynintendoparental/player.py
+++ b/pynintendoparental/player.py
@@ -6,6 +6,16 @@ from .application import ApplicationRegistry, PlayedAppUsage
 from .const import _LOGGER
 
 
+def _is_stale_daily_summary(summary: dict, now: datetime | None = None) -> bool:
+    """Return True when the summary date is before today (Switch has not checked in)."""
+    if now is None:
+        now = datetime.now(timezone.utc)
+    date_str = summary.get("date")
+    if not date_str:
+        return True
+    return datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc).date() < now.date()
+
+
 def parse_played_apps(raw: list[dict], app_registry: ApplicationRegistry) -> list[PlayedAppUsage]:
     """Parse the played apps from a daily summary response.
 
@@ -18,10 +28,7 @@ def parse_played_apps(raw: list[dict], app_registry: ApplicationRegistry) -> lis
     result = []
     for entry in raw:
         # Handle both platform generations
-        app_id = (
-            entry.get("applicationId") or
-            entry.get("meta", {}).get("applicationId")
-        )
+        app_id = entry.get("applicationId") or entry.get("meta", {}).get("applicationId")
         if not app_id:
             continue
         try:
@@ -36,6 +43,7 @@ def parse_played_apps(raw: list[dict], app_registry: ApplicationRegistry) -> lis
             )
         )
     return result
+
 
 class Player:
     """A Nintendo Switch user profile.
@@ -60,22 +68,26 @@ class Player:
         self.player_id: str | None = None
         self.playing_time: int = 0
 
-    def update_from_daily_summary(self, raw: list[dict], app_registry: ApplicationRegistry):
+    def update_from_daily_summary(
+        self,
+        raw: list[dict],
+        app_registry: ApplicationRegistry,
+        now: datetime | None = None,
+    ):
         """Update player data from a daily summary response.
 
         Args:
             raw: List of daily summary dictionaries from the API.
             app_registry: Application registry to use to parse the played apps.
+            now: Clock used to decide if the first summary is today. Defaults to UTC now.
         """
         _LOGGER.debug("Updating player %s daily summary", self.player_id)
         for player in raw[0].get("players", []):
             if self.player_id == player["profile"].get("playerId"):
                 self.player_image = player["profile"].get("imageUri")
                 self.nickname = player["profile"].get("nickname")
-                # Parse the date, to check if it is today or not (ha-core/179748)
-                if datetime.strptime(
-                    raw[0].get("date"), "%Y-%m-%d"
-                ).replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
+                # Nintendo omits today when the Switch has not checked in (ha-core/179748).
+                if _is_stale_daily_summary(raw[0], now):
                     self.playing_time = 0
                     self.apps.clear()
                 else:
@@ -88,11 +100,14 @@ class Player:
         cls,
         raw: list[dict],
         app_registry: ApplicationRegistry,
+        now: datetime | None = None,
     ) -> list["Player"]:
         """Create Player objects from a device daily summary response.
 
         Args:
             raw: List of daily summary dictionaries from the API.
+            app_registry: Application registry to use to parse the played apps.
+            now: Clock used to decide if the first summary is today. Defaults to UTC now.
 
         Returns:
             List of Player objects parsed from the summary.
@@ -104,9 +119,7 @@ class Player:
             parsed.player_id = player["profile"].get("playerId")
             parsed.player_image = player["profile"].get("imageUri")
             parsed.nickname = player["profile"].get("nickname")
-            if datetime.strptime(
-                raw[0].get("date"), "%Y-%m-%d"
-            ).replace(tzinfo=timezone.utc) < datetime.now(timezone.utc):
+            if _is_stale_daily_summary(raw[0], now):
                 parsed.playing_time = 0
                 parsed.apps.clear()
             else:
@@ -131,6 +144,7 @@ class Player:
         parsed.player_image = raw.get("imageUri")
         parsed.nickname = raw.get("nickname")
         return parsed
+
 
 class PlayerRegistry:
     """Registry of players for a device."""

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ DEV_REQUIREMENTS = [
     'build >= 0.10,< 1.6',
     'Faker >= 38,< 41',
     'flake8 >= 6,< 8',
+    'freezegun >= 1.4,< 2',
     'isort >= 5,< 9',
     'mypy >= 1.5,< 2.4',
     'pytest >= 7,< 10',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, PropertyMock, create_autospec
 
 import pytest
+from freezegun import freeze_time
 
 from pynintendoparental import NintendoParental
 from pynintendoparental.api import Api
@@ -16,6 +17,13 @@ from .helpers import load_fixture
 
 # Fixed datetime matching fixture dates (avoids flakiness in snapshots / summaries).
 FIXED_NOW = datetime(2025, 12, 8, 12, 0, 0)
+
+
+@pytest.fixture(autouse=True)
+def freeze_now():
+    """Freeze datetime.now so Player current-day checks match fixture dates."""
+    with freeze_time(FIXED_NOW):
+        yield
 
 
 @pytest.fixture
@@ -69,10 +77,12 @@ def mock_client(mock_api: Api) -> NintendoParental:
     client._api = mock_api
     return client
 
+
 @pytest.fixture
 async def app_registry(device: Device) -> ApplicationRegistry:
     """Fixture for a mocked application registry."""
     return device.applications
+
 
 @pytest.fixture
 def player_registry() -> PlayerRegistry:

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -2,6 +2,7 @@
 
 import copy
 import logging
+from datetime import timedelta
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -9,7 +10,11 @@ from syrupy.assertion import SnapshotAssertion
 from pynintendoparental.application import ApplicationRegistry
 from pynintendoparental.player import Player, PlayerRegistry, parse_played_apps
 
+from .conftest import FIXED_NOW
 from .helpers import load_fixture
+
+# The day after FIXED_NOW — summary date 2025-12-08 is then not today.
+NEXT_DAY = FIXED_NOW + timedelta(days=1)
 
 
 async def test_player_parsing(
@@ -23,6 +28,7 @@ async def test_player_parsing(
     player = players[0]
     assert player == snapshot
 
+
 async def test_player_parsing_with_missing_app(
     caplog: pytest.LogCaptureFixture,
     app_registry: ApplicationRegistry,
@@ -35,6 +41,7 @@ async def test_player_parsing_with_missing_app(
     assert "Application missing_app not found in registry, skipping." in caplog.text
     assert len(players) == 1
     assert players[0].apps == []
+
 
 async def test_player_registry(
     app_registry: ApplicationRegistry,
@@ -50,6 +57,7 @@ async def test_player_registry(
     assert len(player_registry) == 1
     player_registry.remove_player(player.player_id)
     assert len(player_registry) == 0
+
 
 async def test_player_registry_exceptions(
     player_registry: PlayerRegistry,
@@ -67,6 +75,7 @@ async def test_player_registry_exceptions(
     player_registry.add_player(player)
     with pytest.raises(ValueError):
         player_registry.add_player(player)
+
 
 async def test_player_update_from_daily_summary(
     snapshot: SnapshotAssertion,
@@ -99,6 +108,68 @@ async def test_player_update_from_daily_summary(
     assert player.apps[0].playing_time == 100
     assert player == snapshot
 
+
+async def test_player_from_daily_summary_not_today(
+    caplog: pytest.LogCaptureFixture,
+    app_registry: ApplicationRegistry,
+):
+    """When the first summary date is before now, playing time and apps are cleared."""
+    daily_summaries_response = await load_fixture("device_daily_summaries")
+    daily_summaries_response["dailySummaries"][0]["players"][0]["playedGames"][0]["applicationId"] = "missing_app"
+    with caplog.at_level(logging.WARNING):
+        players = Player.from_device_daily_summary(
+            daily_summaries_response["dailySummaries"],
+            app_registry,
+            now=NEXT_DAY,
+        )
+
+    assert len(players) == 1
+    assert players[0].playing_time == 0
+    assert players[0].apps == []
+    assert "Application missing_app not found in registry, skipping." not in caplog.text
+
+
+@pytest.mark.parametrize("missing_date", [None, ""])
+async def test_player_from_daily_summary_missing_date(
+    app_registry: ApplicationRegistry,
+    missing_date: str | None,
+):
+    """A missing summary date is treated as not today."""
+    daily_summaries_response = await load_fixture("device_daily_summaries")
+    daily_summaries_response["dailySummaries"][0]["date"] = missing_date
+    players = Player.from_device_daily_summary(
+        daily_summaries_response["dailySummaries"],
+        app_registry,
+        now=FIXED_NOW,
+    )
+
+    assert len(players) == 1
+    assert players[0].playing_time == 0
+    assert players[0].apps == []
+
+
+async def test_player_update_from_daily_summary_not_today(app_registry: ApplicationRegistry):
+    """Updating after the summary date clears previously parsed today playtime and apps."""
+    daily_summaries_response = await load_fixture("device_daily_summaries")
+    players = Player.from_device_daily_summary(
+        daily_summaries_response["dailySummaries"],
+        app_registry,
+        now=FIXED_NOW,
+    )
+    player = players[0]
+    assert player.playing_time > 0
+    assert player.apps
+
+    player.update_from_daily_summary(
+        daily_summaries_response["dailySummaries"],
+        app_registry,
+        now=NEXT_DAY,
+    )
+
+    assert player.playing_time == 0
+    assert player.apps == []
+
+
 async def test_player_parse_played_apps_ignoring_none(
     app_registry: ApplicationRegistry,
 ):
@@ -111,6 +182,7 @@ async def test_player_parse_played_apps_ignoring_none(
     assert len(apps) == 1
     assert apps[0].application.application_id == "010042D00D900000"
     assert apps[0].playing_time == 100
+
 
 async def test_player_registry_get(
     player_registry: PlayerRegistry,


### PR DESCRIPTION
The player daily summary statistics now reset to zero if the latest API data is not from today. This change ensures that the play time reflects the current day, aligning with the behavior of the Nintendo Parental Controls app.

Fixes home-assistant/core#179748