### PR TITLE
Fix: update datetime handling to use timezone-aware current time

### DIFF
--- a/pynintendoparental/application.py
+++ b/pynintendoparental/application.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 from .api import Api
 from .const import _LOGGER
 from .enum import SafeLaunchSetting
-from .utils import is_awaitable
+from .utils import current_datetime, is_awaitable
 
 if TYPE_CHECKING:
     from .device import Device
@@ -104,7 +104,7 @@ class Application:
             self._api.async_update_restriction_level,
             self._device_id,
             pcs,
-            now=datetime.now(),
+            now=current_datetime(self._api._tz),
         )
 
     async def _internal_update_callback(self, device: "Device"):

--- a/pynintendoparental/device/_callbacks.py
+++ b/pynintendoparental/device/_callbacks.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
-from ..utils import is_awaitable
+from ..utils import current_datetime, is_awaitable
 
 if TYPE_CHECKING:  # pragma: no cover
     from ._core import Device
@@ -70,7 +69,7 @@ class DeviceCallbacksMixin:
         **kwargs,
     ) -> None:
         """Sends an update to the API and refreshes local state."""
-        now = kwargs.pop("now", datetime.now(timezone.utc))
+        now = kwargs.pop("now", current_datetime(self._api._tz))
         response = await api_call(*args, **kwargs)
         self._parse_parental_control_setting(response["json"], now)
         self._calculate_times(now)

--- a/pynintendoparental/device/_core.py
+++ b/pynintendoparental/device/_core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from datetime import datetime, time, timedelta, timezone
+from datetime import datetime, time, timedelta
 
 from pynintendoauth.exceptions import (
     HttpException,
@@ -16,6 +16,7 @@ from ..application import Application, ApplicationRegistry
 from ..const import _LOGGER, DAYS_OF_WEEK
 from ..enum import AlarmSettingState, DeviceTimerMode
 from ..player import Player, PlayerRegistry
+from ..utils import current_datetime
 from ._callbacks import DeviceCallbacksMixin
 from ._parsing import DeviceParsingMixin
 from ._settings import DeviceSettingsMixin
@@ -122,11 +123,12 @@ class Device(
         all associated players and applications.
 
         Args:
-            now: Optional datetime for the update. Defaults to current time if not provided.
+            now: Optional datetime for the update. Defaults to the current time in the
+                API timezone if not provided.
         """
         _LOGGER.debug(">> Device.update()")
         if now is None:
-            now = datetime.now(timezone.utc)
+            now = current_datetime(self._api._tz)
         await asyncio.gather(
             self._get_daily_summaries(now),
             self.get_monthly_summary(),
@@ -288,7 +290,7 @@ class Device(
             ValueError: If no summary exists for the given date or no summaries are available.
         """
         if input_date is None:
-            input_date = datetime.now(timezone.utc)
+            input_date = current_datetime(self._api._tz)
         if not self.daily_summaries:
             raise ValueError("No daily summaries available to search.")
         summary = [x for x in self.daily_summaries if x["date"] == input_date.strftime("%Y-%m-%d")]

--- a/pynintendoparental/device/_settings.py
+++ b/pynintendoparental/device/_settings.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from datetime import datetime, time
+from datetime import time
 from typing import TYPE_CHECKING
 
 from ..api import Api
 from ..const import _LOGGER, DAYS_OF_WEEK
 from ..enum import DeviceTimerMode, FunctionalRestrictionLevel, RestrictionMode
 from ..exceptions import BedtimeOutOfRangeError, InvalidDeviceStateError
+from ..utils import current_datetime
 from ._helpers import (
     apply_time_to_play_in_one_day,
     build_bedtime_dict,
@@ -61,14 +62,14 @@ class DeviceSettingsMixin:
             await self._api.async_confirm_extra_playing_time(self.device_id, minutes, True)
         else:
             await self._api.async_update_extra_playing_time(self.device_id, minutes)
-        await self._get_parental_control_setting(datetime.now())
+        await self._get_parental_control_setting(current_datetime(self._api._tz))
 
     async def cancel_extra_time(self: Device) -> None:  # type: ignore[misc]
         """Cancel extra playing time for the current day."""
         _LOGGER.debug(">> Device.cancel_extra_time()")
         await self._api.async_update_extra_playing_time(self.device_id, cancel=True)
         self.extra_playing_time = None
-        await self._get_parental_control_setting(datetime.now())
+        await self._get_parental_control_setting(current_datetime(self._api._tz))
         await self._execute_callbacks()
 
     async def set_restriction_mode(self: Device, mode: RestrictionMode) -> None:  # type: ignore[misc]
@@ -86,7 +87,7 @@ class DeviceSettingsMixin:
             self.device_id,
             self.parental_control_settings["playTimerRegulations"],
         )
-        now = datetime.now()
+        now = current_datetime(self._api._tz)
         self._parse_parental_control_setting(response["json"], now)  # Don't need to recalculate times
         await self._execute_callbacks()
 
@@ -95,7 +96,7 @@ class DeviceSettingsMixin:
         _LOGGER.debug(">> Device.set_bedtime_alarm(value=%s)", value)
         self._raise_if_extra_playing_time_active()
         validate_bedtime_alarm(value)
-        now = datetime.now()
+        now = current_datetime(self._api._tz)
         regulation = self._get_today_regulation(now)
         enabled = 16 <= value.hour <= 23
         bedtime = {
@@ -121,7 +122,7 @@ class DeviceSettingsMixin:
         _LOGGER.debug(">> Device.set_bedtime_end_time(value=%s)", value)
         self._raise_if_extra_playing_time_active()
         validate_bedtime_end(value)
-        now = datetime.now()
+        now = current_datetime(self._api._tz)
         regulation = self._get_today_regulation(now)
         enabled = not is_bedtime_disabled(value)
         regulation["bedtime"] = {
@@ -246,7 +247,7 @@ class DeviceSettingsMixin:
         self._raise_if_extra_playing_time_active()
         minutes = normalize_playtime_minutes(minutes)
         validate_max_daily_playtime(minutes)
-        now = datetime.now()
+        now = current_datetime(self._api._tz)
         limit = None if minutes == -1 else minutes
         regulation = self._get_today_regulation(now)
         _LOGGER.debug(

--- a/pynintendoparental/player.py
+++ b/pynintendoparental/player.py
@@ -1,20 +1,24 @@
 """Nintendo Player."""
 
 from collections.abc import Iterator
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 from .application import ApplicationRegistry, PlayedAppUsage
 from .const import _LOGGER
 
 
 def _is_stale_daily_summary(summary: dict, now: datetime | None = None) -> bool:
-    """Return True when the summary date is before today (Switch has not checked in)."""
+    """Return True when the summary date is before today (Switch has not checked in).
+
+    ``now`` must be in the same timezone used for Nintendo API requests
+    (``X-Moon-TimeZone``). The API ``date`` field is a civil date in that zone.
+    """
     if now is None:
         now = datetime.now(timezone.utc)
     date_str = summary.get("date")
     if not date_str:
         return True
-    return datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc).date() < now.date()
+    return date.fromisoformat(date_str) < now.date()
 
 
 def parse_played_apps(raw: list[dict], app_registry: ApplicationRegistry) -> list[PlayedAppUsage]:
@@ -80,7 +84,8 @@ class Player:
         Args:
             raw: List of daily summary dictionaries from the API.
             app_registry: Application registry to use to parse the played apps.
-            now: Clock used to decide if the first summary is today. Defaults to UTC now.
+            now: Clock used to decide if the first summary is today. Should be in the
+                API timezone. Defaults to UTC now.
         """
         _LOGGER.debug("Updating player %s daily summary", self.player_id)
         for player in raw[0].get("players", []):
@@ -108,7 +113,8 @@ class Player:
         Args:
             raw: List of daily summary dictionaries from the API.
             app_registry: Application registry to use to parse the played apps.
-            now: Clock used to decide if the first summary is today. Defaults to UTC now.
+            now: Clock used to decide if the first summary is today. Should be in the
+                API timezone. Defaults to UTC now.
 
         Returns:
             List of Player objects parsed from the summary.

--- a/pynintendoparental/utils.py
+++ b/pynintendoparental/utils.py
@@ -1,8 +1,15 @@
 """Generic utilities."""
 
 import inspect
+from datetime import datetime
+from zoneinfo import ZoneInfo
 
 
 def is_awaitable(func):
     """Check if a function is awaitable or not."""
     return inspect.iscoroutinefunction(func) or inspect.isasyncgenfunction(func)
+
+
+def current_datetime(tz: str) -> datetime:
+    """Return the current time in the given IANA timezone."""
+    return datetime.now(ZoneInfo(tz))

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -4,8 +4,10 @@ import copy
 import logging
 from datetime import datetime, time, timezone
 from unittest.mock import AsyncMock, Mock, patch
+from zoneinfo import ZoneInfo
 
 import pytest
+from freezegun import freeze_time
 from pynintendoauth.exceptions import HttpException
 from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
@@ -971,3 +973,65 @@ async def test_parse_extra_playing_time_bedtime_without_end_time(device: Device,
 
     assert device.extra_playing_time is None
     assert device.bedtime_alarm == time(21, 0)
+
+
+async def test_update_zeros_playtime_after_local_midnight(device: Device):
+    """Yesterday's summary is stale after local midnight in a positive-offset zone."""
+    now = datetime(2025, 12, 9, 0, 30, tzinfo=ZoneInfo("Asia/Tokyo"))
+    await device.update(now=now)
+
+    assert device.today_playing_time == 0
+    assert all(player.playing_time == 0 for player in device.players)
+
+
+async def test_update_keeps_playtime_before_local_midnight_negative_offset(device: Device):
+    """Today's summary is not stale during a US evening when UTC has already rolled."""
+    now = datetime(2025, 12, 8, 17, 30, tzinfo=ZoneInfo("America/Los_Angeles"))
+    await device.update(now=now)
+
+    assert device.today_playing_time == 60
+    assert any(player.playing_time > 0 for player in device.players)
+
+
+@pytest.mark.parametrize(
+    "tz, frozen, summary_date, expect_zero",
+    [
+        pytest.param(
+            "Europe/London",
+            datetime(2025, 6, 1, 23, 30, tzinfo=timezone.utc),
+            "2025-06-01",
+            True,
+            id="bst_after_local_midnight",
+        ),
+        pytest.param(
+            "America/Los_Angeles",
+            datetime(2025, 6, 2, 0, 30, tzinfo=timezone.utc),
+            "2025-06-01",
+            False,
+            id="pdt_evening_utc_next_day",
+        ),
+    ],
+)
+async def test_update_default_now_uses_api_timezone(
+    device: Device,
+    mock_api: Api,
+    tz: str,
+    frozen: datetime,
+    summary_date: str,
+    expect_zero: bool,
+):
+    """Device.update() without now uses the API timezone, not UTC."""
+    summaries = await load_fixture("device_daily_summaries")
+    summaries["dailySummaries"][0]["date"] = summary_date
+    mock_api.async_get_device_daily_summaries.return_value = {"json": summaries}
+    mock_api._tz = tz
+
+    with freeze_time(frozen):
+        await device.update()
+
+    if expect_zero:
+        assert device.today_playing_time == 0
+        assert all(player.playing_time == 0 for player in device.players)
+    else:
+        assert device.today_playing_time == 60
+        assert any(player.playing_time > 0 for player in device.players)

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -2,13 +2,14 @@
 
 import copy
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from pynintendoparental.application import ApplicationRegistry
-from pynintendoparental.player import Player, PlayerRegistry, parse_played_apps
+from pynintendoparental.player import Player, PlayerRegistry, _is_stale_daily_summary, parse_played_apps
 
 from .conftest import FIXED_NOW
 from .helpers import load_fixture
@@ -193,3 +194,38 @@ async def test_player_registry_get(
     player_registry.add_player(player)
     assert player_registry.get(player.player_id) == player
     assert player_registry.get("missing_player") is None
+
+
+@pytest.mark.parametrize(
+    "now, expected_stale",
+    [
+        pytest.param(
+            datetime(2025, 12, 9, 0, 30, tzinfo=ZoneInfo("Asia/Tokyo")),
+            True,
+            id="tokyo_after_local_midnight",
+        ),
+        pytest.param(
+            datetime(2025, 12, 8, 23, 30, tzinfo=ZoneInfo("Asia/Tokyo")),
+            False,
+            id="tokyo_before_local_midnight",
+        ),
+        pytest.param(
+            datetime(2025, 12, 8, 17, 30, tzinfo=ZoneInfo("America/Los_Angeles")),
+            False,
+            id="la_evening_utc_already_next_day",
+        ),
+        pytest.param(
+            datetime(2025, 12, 9, 0, 0, tzinfo=ZoneInfo("America/Los_Angeles")),
+            True,
+            id="la_local_midnight",
+        ),
+        pytest.param(
+            datetime(2025, 12, 8, 12, 0, tzinfo=ZoneInfo("Europe/London")),
+            False,
+            id="london_noon_same_day",
+        ),
+    ],
+)
+def test_is_stale_daily_summary_timezone_boundaries(now: datetime, expected_stale: bool):
+    """Stale checks use the civil date of ``now``, not a UTC-tagged API date."""
+    assert _is_stale_daily_summary({"date": "2025-12-08"}, now) is expected_stale

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+"""Tests for generic utilities."""
+
+from datetime import datetime, timezone
+
+from freezegun import freeze_time
+
+from pynintendoparental.utils import current_datetime
+
+
+def test_current_datetime_uses_iana_zone():
+    """current_datetime returns the civil date in the requested zone."""
+    with freeze_time(datetime(2025, 6, 1, 23, 30, tzinfo=timezone.utc)):
+        london = current_datetime("Europe/London")
+        assert london.date().isoformat() == "2025-06-02"
+
+        los_angeles = current_datetime("America/Los_Angeles")
+        assert los_angeles.date().isoformat() == "2025-06-01"


### PR DESCRIPTION
Replaced instances of `datetime.now()` with a new utility function `current_datetime()` that retrieves the current time in the specified API timezone. This change ensures consistent timezone handling across the library, particularly in the Device and Player classes, improving the accuracy of daily summary updates and parental control settings.