### PR TITLE
Enhance extra playing time functionality in parental controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ All methods are asynchronous.
 - `add_device_callback(callback)`: Adds a callback that will be called when the device state changes.
 - `remove_device_callback(callback)`: Removes a previously added callback.
 - `set_new_pin(pin: str)`: Sets a new PIN for the parental controls.
-- `add_extra_time(minutes: int)`: Adds extra playing time for the current day.
+- `add_extra_time(minutes: int)`: Adds extra playing time for the current day (`-1` for unlimited). Raises `ExtraPlayingTimeRequestError` if Nintendo rejects the request (e.g. `NO_EFFECT` when play time can't be extended any further today, or `OVERTIME_ERROR` when it would run past bedtime).
+- `cancel_extra_time()`: Revokes today's extra playing time.
 - `update_max_daily_playtime(minutes: int)`: Sets the daily playtime limit. Use `-1` to remove the limit.
 - `set_restriction_mode(mode: RestrictionMode)`: Sets the restriction mode.
     - `RestrictionMode.FORCED_TERMINATION`: The software will be suspended when the playtime limit is reached.

--- a/docs/guide/examples.md
+++ b/docs/guide/examples.md
@@ -63,13 +63,33 @@ await remove_playtime_limit(device)
 ### Add Extra Time
 
 ```python
+from pynintendoparental.exceptions import ExtraPlayingTimeRequestError
+
 async def add_extra_time(device, minutes: int):
     """Add extra playing time for today."""
-    await device.add_extra_time(minutes)
+    try:
+        await device.add_extra_time(minutes)
+    except ExtraPlayingTimeRequestError as err:
+        # Nintendo answers HTTP 200 even when it rejects the request; the
+        # outcome is reported via a status such as NO_EFFECT or OVERTIME_ERROR.
+        print(f"Nintendo rejected the request: {err.status}")
+        return
     print(f"Added {minutes} minutes of extra time")
 
 # Usage
 await add_extra_time(device, 30)  # Add 30 minutes
+```
+
+### Cancel Extra Time
+
+```python
+async def cancel_extra_time(device):
+    """Revoke today's extra playing time."""
+    await device.cancel_extra_time()
+    print("Extra time cancelled")
+
+# Usage
+await cancel_extra_time(device)
 ```
 
 ## Bedtime Settings

--- a/pynintendoparental/api.py
+++ b/pynintendoparental/api.py
@@ -16,10 +16,37 @@ from .const import (
     OS_VERSION,
     USER_AGENT,
 )
+from .enum import ExtraPlayingTimeStatus
+from .exceptions import ExtraPlayingTimeRequestError
 
 
 def _check_http_success(status: int) -> bool:
     return status >= 200 and status < 300
+
+
+def _check_extra_playing_time_response(response: dict) -> None:
+    """Raise if an extra-playing-time response reports a rejected request.
+
+    Nintendo answers HTTP 200 regardless of outcome; the official app switches on
+    the JSON ``status`` field instead. A missing or unrecognised status is treated
+    as success so that a future API change does not break working setups.
+    """
+    payload = response.get("json") or {}
+    raw_status = payload.get("status")
+    _LOGGER.debug(
+        "Extra playing time response: status=%s nextStepDetail=%s",
+        raw_status,
+        payload.get("nextStepDetail"),
+    )
+    if raw_status is None:
+        return
+    try:
+        status = ExtraPlayingTimeStatus(raw_status)
+    except ValueError:
+        _LOGGER.warning("Unrecognised extra playing time status %r; assuming success", raw_status)
+        return
+    if status.is_error:
+        raise ExtraPlayingTimeRequestError(status, response)
 
 
 class Api:
@@ -170,36 +197,56 @@ class Api:
             body={"deviceId": device_id, "unlockCode": str(new_code)},
         )
 
-    async def async_confirm_extra_playing_time(
-        self, device_id: str, additional_time: int, with_bedtime: bool
-    ) -> dict:
+    async def async_confirm_extra_playing_time(self, device_id: str, additional_time: int, with_bedtime: bool) -> dict:
         """Confirm (grant) extra playing time for the current day.
+
+        The official app only calls this as the second step after
+        ``updateExtraPlayingTime`` returned ``nextStepDetail`` (the grant would
+        run into bedtime and needs confirming).
 
         Args:
             device_id: The Nintendo device ID.
             additional_time: Number of additional minutes to grant.
-            with_bedtime: When True, the bonus is granted relative to the
-                bedtime limit; when False it extends the inOneDay play limit.
+            with_bedtime: When True, bedtime is pushed back along with the
+                play limit; when False only the inOneDay play limit is extended.
+
+        Raises:
+            ExtraPlayingTimeRequestError: If Nintendo rejected the request.
         """
         body = {
             "deviceId": device_id,
             "additionalTime": additional_time,
             "withBedtime": with_bedtime,
         }
-        return await self.send_request(endpoint="confirm_extra_playing_time", body=body)
+        response = await self.send_request(endpoint="confirm_extra_playing_time", body=body)
+        _check_extra_playing_time_response(response)
+        return response
 
-    async def async_update_extra_playing_time(self, device_id: str, additional_time: int | None = None, cancel: bool = False) -> dict:
-        """Add or cancel extra playing time via the daily inOneDay limit (no-bedtime path)."""
-        body = {
+    async def async_update_extra_playing_time(
+        self, device_id: str, additional_time: int | None = None, cancel: bool = False
+    ) -> dict:
+        """Add, make unlimited, or cancel extra playing time for the current day.
+
+        Args:
+            device_id: The Nintendo device ID.
+            additional_time: Minutes to add, or -1 for unlimited.
+            cancel: When True, revoke today's extra playing time.
+
+        Raises:
+            ExtraPlayingTimeRequestError: If Nintendo rejected the request.
+        """
+        body: dict[str, object] = {
             "deviceId": device_id,
         }
         if cancel:
-            body["status"] = "TO_CANCELLED"
-        elif additional_time == -1 and not cancel:
-            body["status"] = "TO_INFINITY"
+            body["status"] = ExtraPlayingTimeStatus.TO_CANCELED.value
+        elif additional_time == -1:
+            body["status"] = ExtraPlayingTimeStatus.TO_INFINITY.value
         elif additional_time is not None:
             body["additionalTime"] = additional_time
-            body["status"] = "TO_ADDED"
+            body["status"] = ExtraPlayingTimeStatus.TO_ADDED.value
         else:
             raise ValueError("Additional time must be provided if not canceling")
-        return await self.send_request(endpoint="update_extra_playing_time", body=body)
+        response = await self.send_request(endpoint="update_extra_playing_time", body=body)
+        _check_extra_playing_time_response(response)
+        return response

--- a/pynintendoparental/device/_settings.py
+++ b/pynintendoparental/device/_settings.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import time
 from typing import TYPE_CHECKING
 
@@ -28,6 +29,11 @@ from ._helpers import (
 if TYPE_CHECKING:  # pragma: no cover
     from ._core import Device
 
+# How long to keep re-reading parental control settings after an extra playing
+# time mutation before giving up on seeing the change reflected.
+EXTRA_PLAYING_TIME_SYNC_ATTEMPTS = 3
+EXTRA_PLAYING_TIME_SYNC_DELAY = 2.0
+
 
 class DeviceSettingsMixin:
     """Mixin providing parental-control mutation APIs on Device."""
@@ -38,6 +44,7 @@ class DeviceSettingsMixin:
     timer_mode: DeviceTimerMode | None
     bedtime_alarm: time | None
     alarms_enabled: bool
+    extra_playing_time: int | None
 
     async def set_new_pin(self: Device, pin: str) -> None:  # type: ignore[misc]
         """Set a new PIN code for parental controls on this device.
@@ -55,22 +62,49 @@ class DeviceSettingsMixin:
             minutes: Number of additional minutes to add (must be positive).
         """
         _LOGGER.debug(">> Device.add_extra_time(minutes=%s)", minutes)
-        with_bedtime = (
-            self.bedtime_alarm is not None and not is_bedtime_disabled(self.bedtime_alarm) and self.alarms_enabled
-        )
-        if minutes != -1 and with_bedtime:
+        previous = self.extra_playing_time
+        response = await self._api.async_update_extra_playing_time(self.device_id, minutes)
+        # Nintendo asks for confirmation when the grant would run into bedtime;
+        # the official app then confirms with withBedtime=True to push bedtime back too.
+        if (response.get("json") or {}).get("nextStepDetail"):
+            _LOGGER.debug("Extra playing time requires bedtime confirmation, confirming")
             await self._api.async_confirm_extra_playing_time(self.device_id, minutes, True)
-        else:
-            await self._api.async_update_extra_playing_time(self.device_id, minutes)
-        await self._get_parental_control_setting(current_datetime(self._api._tz))
+        await self._refresh_extra_playing_time(previous)
+        await self._execute_callbacks()
 
     async def cancel_extra_time(self: Device) -> None:  # type: ignore[misc]
         """Cancel extra playing time for the current day."""
         _LOGGER.debug(">> Device.cancel_extra_time()")
+        previous = self.extra_playing_time
         await self._api.async_update_extra_playing_time(self.device_id, cancel=True)
         self.extra_playing_time = None
-        await self._get_parental_control_setting(current_datetime(self._api._tz))
+        await self._refresh_extra_playing_time(previous)
         await self._execute_callbacks()
+
+    async def _refresh_extra_playing_time(self: Device, previous: int | None) -> None:  # type: ignore[misc]
+        """Re-read parental control settings until the extra time change is visible.
+
+        fetchParentalControlSetting lags behind extra-playing-time mutations by
+        several seconds; the official app polls rather than trusting the first read.
+        """
+        for attempt in range(1, EXTRA_PLAYING_TIME_SYNC_ATTEMPTS + 1):
+            await self._get_parental_control_setting(current_datetime(self._api._tz))
+            if self.extra_playing_time != previous:
+                return
+            if attempt < EXTRA_PLAYING_TIME_SYNC_ATTEMPTS:
+                _LOGGER.debug(
+                    "Extra playing time still %s after refresh %s/%s, retrying in %ss",
+                    self.extra_playing_time,
+                    attempt,
+                    EXTRA_PLAYING_TIME_SYNC_ATTEMPTS,
+                    EXTRA_PLAYING_TIME_SYNC_DELAY,
+                )
+                await asyncio.sleep(EXTRA_PLAYING_TIME_SYNC_DELAY)
+        _LOGGER.debug(
+            "Extra playing time unchanged (%s) after %s refreshes",
+            self.extra_playing_time,
+            EXTRA_PLAYING_TIME_SYNC_ATTEMPTS,
+        )
 
     async def set_restriction_mode(self: Device, mode: RestrictionMode) -> None:  # type: ignore[misc]
         """Set the restriction mode for playtime limits.

--- a/pynintendoparental/enum.py
+++ b/pynintendoparental/enum.py
@@ -57,3 +57,35 @@ class FunctionalRestrictionLevel(StrEnum, NintendoEnum):
 
     def __str__(self) -> str:
         return self.value
+
+
+class ExtraPlayingTimeStatus(StrEnum, NintendoEnum):
+    """Extra playing time statuses.
+
+    Used both as the request ``status`` for ``updateExtraPlayingTime`` and as
+    the response ``status`` of both extra-playing-time endpoints. Nintendo
+    returns HTTP 200 even when the request was rejected, so the response
+    status is the only reliable success indicator.
+    """
+
+    TO_ADDED = "TO_ADDED"
+    TO_CANCELED = "TO_CANCELED"
+    TO_INFINITY = "TO_INFINITY"
+    SUCCESS = "SUCCESS"
+    NO_EFFECT = "NO_EFFECT"
+    OVERTIME_ERROR = "OVERTIME_ERROR"
+    DURING_LATE_NIGHT_ERROR = "DURING_LATE_NIGHT_ERROR"
+    FAILED = "FAILED"
+
+    def __str__(self) -> str:
+        return self.value
+
+    @property
+    def is_error(self) -> bool:
+        """Return True if the status indicates the request was not applied."""
+        return self in (
+            ExtraPlayingTimeStatus.NO_EFFECT,
+            ExtraPlayingTimeStatus.OVERTIME_ERROR,
+            ExtraPlayingTimeStatus.DURING_LATE_NIGHT_ERROR,
+            ExtraPlayingTimeStatus.FAILED,
+        )

--- a/pynintendoparental/exceptions.py
+++ b/pynintendoparental/exceptions.py
@@ -2,6 +2,8 @@
 
 from enum import StrEnum
 
+from .enum import ExtraPlayingTimeStatus
+
 
 class RangeErrorKeys(StrEnum):
     """Keys for range errors."""
@@ -10,6 +12,16 @@ class RangeErrorKeys(StrEnum):
     BEDTIME = "bedtime_alarm_out_of_range"
     INVALID_DEVICE_STATE = "invalid_device_state"
     EXTRA_PLAYING_TIME_ACTIVE = "extra_playing_time_active"
+    EXTRA_PLAYING_TIME_REQUEST_FAILED = "extra_playing_time_request_failed"
+
+
+# Mirrors the copy the official app shows for each rejected status.
+_EXTRA_PLAYING_TIME_STATUS_MESSAGES: dict[ExtraPlayingTimeStatus, str] = {
+    ExtraPlayingTimeStatus.NO_EFFECT: "Nintendo made no change; play time can't be extended any more today.",
+    ExtraPlayingTimeStatus.OVERTIME_ERROR: "Play time can't be extended past the set bedtime.",
+    ExtraPlayingTimeStatus.DURING_LATE_NIGHT_ERROR: "Play time can't be extended during the late-night block.",
+    ExtraPlayingTimeStatus.FAILED: "Nintendo reported the request failed.",
+}
 
 
 class NoDevicesFoundException(Exception):
@@ -54,6 +66,7 @@ class InvalidDeviceStateError(DeviceError):
 
     error_key = RangeErrorKeys.INVALID_DEVICE_STATE
 
+
 class ExtraPlayingTimeActiveError(DeviceError):
     """Extra playing time is active for the current day."""
 
@@ -61,7 +74,19 @@ class ExtraPlayingTimeActiveError(DeviceError):
     extra_playing_time: int
 
     def __init__(self, extra_playing_time: int) -> None:
-        super().__init__(
-            f"Extra playing time is active for the current day: {extra_playing_time} minutes"
-        )
+        super().__init__(f"Extra playing time is active for the current day: {extra_playing_time} minutes")
         self.extra_playing_time = extra_playing_time
+
+
+class ExtraPlayingTimeRequestError(DeviceError):
+    """Nintendo rejected the extra playing time request."""
+
+    error_key = RangeErrorKeys.EXTRA_PLAYING_TIME_REQUEST_FAILED
+    status: ExtraPlayingTimeStatus
+    response: dict
+
+    def __init__(self, status: ExtraPlayingTimeStatus, response: dict) -> None:
+        detail = _EXTRA_PLAYING_TIME_STATUS_MESSAGES.get(status, "Unexpected response from Nintendo.")
+        super().__init__(f"{detail} (status: {status})")
+        self.status = status
+        self.response = response

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,8 @@ from pynintendoauth.exceptions import HttpException
 
 from pynintendoparental.api import Api, _check_http_success
 from pynintendoparental.authenticator import Authenticator
+from pynintendoparental.enum import ExtraPlayingTimeStatus
+from pynintendoparental.exceptions import ExtraPlayingTimeRequestError
 
 
 @pytest.mark.parametrize("status, expected", [(200, True), (204, True), (300, False), (404, False)])
@@ -124,7 +126,7 @@ async def test_send_request_json_decode_error(mock_authenticator: Authenticator)
 async def test_api_methods(mock_authenticator: Authenticator):
     """Test that API methods call send_request with correct parameters."""
     api = Api(auth=mock_authenticator, tz="Europe/London", lang="en-GB")
-    api.send_request = AsyncMock()
+    api.send_request = AsyncMock(return_value={"json": {}})
 
     await api.async_get_account_devices()
     api.send_request.assert_called_with(endpoint="get_account_devices")
@@ -199,9 +201,9 @@ async def test_api_methods(mock_authenticator: Authenticator):
 
 @pytest.mark.parametrize("additional_time, cancel, expected_body", [
     (15, False, {"deviceId": "DEVICE_ID", "additionalTime": 15, "status": "TO_ADDED"}),
-    (30, True, {"deviceId": "DEVICE_ID", "status": "TO_CANCELLED"}),
+    (30, True, {"deviceId": "DEVICE_ID", "status": "TO_CANCELED"}),
     (-1, False, {"deviceId": "DEVICE_ID", "status": "TO_INFINITY"}),
-    (None, True, {"deviceId": "DEVICE_ID", "status": "TO_CANCELLED"}),
+    (None, True, {"deviceId": "DEVICE_ID", "status": "TO_CANCELED"}),
 ])
 async def test_async_update_extra_playing_time(
     mock_authenticator: Authenticator,
@@ -211,6 +213,57 @@ async def test_async_update_extra_playing_time(
 ):
     """Test async_update_extra_playing_time with different parameters."""
     api = Api(auth=mock_authenticator, tz="Europe/London", lang="en-GB")
-    api.send_request = AsyncMock()
+    api.send_request = AsyncMock(return_value={"json": {"status": expected_body["status"]}})
     await api.async_update_extra_playing_time("DEVICE_ID", additional_time, cancel)
     api.send_request.assert_called_with(endpoint="update_extra_playing_time", body=expected_body)
+    # Body status must be a plain string so it serialises as Nintendo expects.
+    sent_status = api.send_request.call_args.kwargs["body"]["status"]
+    assert type(sent_status) is str  # pylint: disable=unidiomatic-typecheck
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["NO_EFFECT", "OVERTIME_ERROR", "DURING_LATE_NIGHT_ERROR", "FAILED"],
+)
+@pytest.mark.parametrize("method", ["update", "confirm"])
+async def test_extra_playing_time_error_status_raises(
+    mock_authenticator: Authenticator, status: str, method: str
+):
+    """HTTP 200 with a rejected status must surface as ExtraPlayingTimeRequestError."""
+    api = Api(auth=mock_authenticator, tz="Europe/London", lang="en-GB")
+    response = {"status": 200, "json": {"deviceId": "DEVICE_ID", "status": status}}
+    api.send_request = AsyncMock(return_value=response)
+
+    with pytest.raises(ExtraPlayingTimeRequestError) as err:
+        if method == "update":
+            await api.async_update_extra_playing_time("DEVICE_ID", 15)
+        else:
+            await api.async_confirm_extra_playing_time("DEVICE_ID", 15, True)
+
+    assert err.value.status == ExtraPlayingTimeStatus(status)
+    assert err.value.response is response
+    assert err.value.error_key == "extra_playing_time_request_failed"
+    assert status in str(err.value)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"status": "TO_ADDED"}, id="to_added"),
+        pytest.param({"status": "SUCCESS"}, id="success"),
+        pytest.param({"status": "TO_CANCELED"}, id="to_canceled"),
+        pytest.param({"status": "TO_INFINITY"}, id="to_infinity"),
+        pytest.param({}, id="missing_status"),
+        pytest.param({"status": "SOMETHING_NEW"}, id="unknown_status"),
+    ],
+)
+async def test_extra_playing_time_success_status_returns_response(
+    mock_authenticator: Authenticator, payload: dict
+):
+    """Success, missing and unrecognised statuses are all treated as success."""
+    api = Api(auth=mock_authenticator, tz="Europe/London", lang="en-GB")
+    response = {"status": 200, "json": payload}
+    api.send_request = AsyncMock(return_value=response)
+
+    assert await api.async_update_extra_playing_time("DEVICE_ID", 15) is response
+    assert await api.async_confirm_extra_playing_time("DEVICE_ID", 15, False) is response

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -13,9 +13,10 @@ from syrupy.assertion import SnapshotAssertion
 from syrupy.filters import props
 
 from pynintendoparental.api import Api
-from pynintendoparental.device import Device
+from pynintendoparental.device import Device, _settings
 from pynintendoparental.enum import (
     DeviceTimerMode,
+    ExtraPlayingTimeStatus,
     FunctionalRestrictionLevel,
     RestrictionMode,
 )
@@ -23,6 +24,7 @@ from pynintendoparental.exceptions import (
     BedtimeOutOfRangeError,
     DailyPlaytimeOutOfRangeError,
     ExtraPlayingTimeActiveError,
+    ExtraPlayingTimeRequestError,
     InvalidDeviceStateError,
 )
 
@@ -488,44 +490,139 @@ async def test_set_new_pin(device: Device, mock_api: Api, pin: str):
     mock_api.async_update_unlock_code.assert_called_with(new_code=pin, device_id=device.device_id)
 
 
+@pytest.fixture(autouse=True)
+def no_extra_time_sync_delay(monkeypatch: pytest.MonkeyPatch):
+    """Don't sleep between PCS re-reads after extra playing time mutations."""
+    monkeypatch.setattr(_settings, "EXTRA_PLAYING_TIME_SYNC_DELAY", 0)
+
+
 @pytest.mark.parametrize(
     "extra_time",
     [
         pytest.param(10),
         pytest.param(0),
+        pytest.param(-1, id="infinity"),
     ],
 )
-async def test_add_extra_time(device: Device, mock_api: Api, extra_time: int):
-    """Test that the add_extra_time method works as expected."""
-    mock_api.async_update_extra_playing_time.return_value = None
+async def test_add_extra_time(device: Device, mock_api: Api, pcs: dict, extra_time: int):
+    """add_extra_time posts updateExtraPlayingTime and refreshes state; no confirm step by default."""
+    mock_api.async_update_extra_playing_time.return_value = {"json": {"status": "TO_ADDED"}}
+    mock_api.async_get_device_parental_control_setting.return_value = {
+        "json": pcs_with_extra_in_one_day(pcs, duration=None if extra_time == -1 else extra_time, is_infinity=extra_time == -1)
+    }
+    callback = Mock()
+    device.add_device_callback(callback)
 
     await device.add_extra_time(extra_time)
-    mock_api.async_update_extra_playing_time.assert_called_with(device.device_id, extra_time)
+
+    mock_api.async_update_extra_playing_time.assert_called_once_with(device.device_id, extra_time)
+    mock_api.async_confirm_extra_playing_time.assert_not_called()
+    assert device.extra_playing_time == extra_time
+    callback.assert_called_once()
+
+
+async def test_add_extra_time_with_bedtime_does_not_confirm_without_next_step(device: Device, mock_api: Api, pcs: dict):
+    """Bedtime being active is no longer enough to call confirmExtraPlayingTime."""
+    device.bedtime_alarm = time(hour=21, minute=0)
+    device.alarms_enabled = True
+    mock_api.async_update_extra_playing_time.return_value = {"json": {"status": "TO_ADDED", "nextStepDetail": None}}
+    mock_api.async_get_device_parental_control_setting.return_value = {"json": pcs_with_extra_in_one_day(pcs, 15)}
+
+    await device.add_extra_time(15)
+
+    mock_api.async_update_extra_playing_time.assert_called_once_with(device.device_id, 15)
     mock_api.async_confirm_extra_playing_time.assert_not_called()
 
 
-async def test_add_extra_time_with_bedtime(device: Device, mock_api: Api):
-    """Test add_extra_time uses confirmExtraPlayingTime when bedtime is active."""
-    device.bedtime_alarm = time(hour=21, minute=0)
-    device.alarms_enabled = True
-
-    mock_api.async_confirm_extra_playing_time.return_value = None
+async def test_add_extra_time_confirms_when_next_step_requested(device: Device, mock_api: Api, pcs: dict):
+    """When Nintendo returns nextStepDetail the grant is confirmed with withBedtime=True."""
+    mock_api.async_update_extra_playing_time.return_value = {
+        "json": {
+            "status": "TO_ADDED",
+            "nextStepDetail": {
+                "estimatedBedtimeChanges": {"from": {"hour": 21, "minute": 0}, "to": {"hour": 21, "minute": 15}}
+            },
+        }
+    }
+    mock_api.async_confirm_extra_playing_time.return_value = {"json": {"status": "SUCCESS"}}
+    mock_api.async_get_device_parental_control_setting.return_value = {"json": pcs_with_extra_in_one_day(pcs, 15)}
 
     await device.add_extra_time(15)
-    mock_api.async_confirm_extra_playing_time.assert_called_with(device.device_id, 15, True)
-    mock_api.async_update_extra_playing_time.assert_not_called()
+
+    mock_api.async_update_extra_playing_time.assert_called_once_with(device.device_id, 15)
+    mock_api.async_confirm_extra_playing_time.assert_called_once_with(device.device_id, 15, True)
+    assert device.extra_playing_time == 15
+
+
+async def test_add_extra_time_propagates_request_error(device: Device, mock_api: Api):
+    """A rejected status from the API bubbles up and no refresh is attempted."""
+    mock_api.async_update_extra_playing_time.side_effect = ExtraPlayingTimeRequestError(
+        ExtraPlayingTimeStatus.NO_EFFECT, {"json": {"status": "NO_EFFECT"}}
+    )
+    mock_api.async_get_device_parental_control_setting.reset_mock()
+
+    with pytest.raises(ExtraPlayingTimeRequestError) as err:
+        await device.add_extra_time(15)
+
+    assert err.value.status is ExtraPlayingTimeStatus.NO_EFFECT
+    mock_api.async_confirm_extra_playing_time.assert_not_called()
+    mock_api.async_get_device_parental_control_setting.assert_not_called()
+
+
+async def test_add_extra_time_polls_until_pcs_reflects_change(device: Device, mock_api: Api, pcs: dict):
+    """Stale PCS reads after a grant are retried until the extra time shows up."""
+    mock_api.async_update_extra_playing_time.return_value = {"json": {"status": "TO_ADDED"}}
+    mock_api.async_get_device_parental_control_setting.reset_mock()
+    mock_api.async_get_device_parental_control_setting.side_effect = [
+        {"json": pcs},  # stale: still no extra time
+        {"json": pcs_with_extra_in_one_day(pcs, 30)},
+        {"json": pcs_with_extra_in_one_day(pcs, 30)},
+    ]
+
+    await device.add_extra_time(30)
+
+    assert mock_api.async_get_device_parental_control_setting.call_count == 2
+    assert device.extra_playing_time == 30
+
+
+async def test_add_extra_time_gives_up_polling_after_max_attempts(device: Device, mock_api: Api, pcs: dict):
+    """If the PCS never reflects the change we stop after the configured attempts."""
+    mock_api.async_update_extra_playing_time.return_value = {"json": {"status": "TO_ADDED"}}
+    mock_api.async_get_device_parental_control_setting.reset_mock()
+    mock_api.async_get_device_parental_control_setting.return_value = {"json": pcs}
+
+    await device.add_extra_time(30)
+
+    assert mock_api.async_get_device_parental_control_setting.call_count == _settings.EXTRA_PLAYING_TIME_SYNC_ATTEMPTS
+    assert device.extra_playing_time is None
 
 
 async def test_cancel_extra_time(device: Device, mock_api: Api):
     """Test cancel_extra_time clears local state and refreshes from the API."""
     device.extra_playing_time = 30
-    mock_api.async_update_extra_playing_time.return_value = None
+    mock_api.async_update_extra_playing_time.return_value = {"json": {"status": "TO_CANCELED"}}
     mock_api.async_get_device_parental_control_setting.reset_mock()
 
     await device.cancel_extra_time()
 
     mock_api.async_update_extra_playing_time.assert_called_with(device.device_id, cancel=True)
-    mock_api.async_get_device_parental_control_setting.assert_called()
+    mock_api.async_get_device_parental_control_setting.assert_called_once()
+    assert device.extra_playing_time is None
+
+
+async def test_cancel_extra_time_polls_stale_pcs(device: Device, mock_api: Api, pcs: dict):
+    """A stale PCS that still shows the extra time is re-read."""
+    device.extra_playing_time = 30
+    mock_api.async_update_extra_playing_time.return_value = {"json": {"status": "TO_CANCELED"}}
+    mock_api.async_get_device_parental_control_setting.reset_mock()
+    mock_api.async_get_device_parental_control_setting.side_effect = [
+        {"json": pcs_with_extra_in_one_day(pcs, 30)},
+        {"json": pcs},
+    ]
+
+    await device.cancel_extra_time()
+
+    assert mock_api.async_get_device_parental_control_setting.call_count == 2
     assert device.extra_playing_time is None
 
 


### PR DESCRIPTION
- Updated `add_extra_time` method to handle unlimited time requests and raise `ExtraPlayingTimeRequestError` for rejected requests.
- Introduced `cancel_extra_time` method to revoke extra playing time.
- Added `ExtraPlayingTimeStatus` enum to manage response statuses from Nintendo.
- Implemented error handling for extra playing time requests in the API.
- Updated documentation and examples to reflect new functionality.
- Enhanced tests to cover new features and error handling scenarios.